### PR TITLE
Removing debugging log messages

### DIFF
--- a/core-linux/src/Handler.cpp
+++ b/core-linux/src/Handler.cpp
@@ -43,7 +43,6 @@ void Handler::handle(int _connfd)
     _request = p.getParseResult();
 
     pair<string, string> resp = routes::handle(_request.uri, _request.body, _request.auth);
-    std::cout << "url = " << _request.uri << " id = " << _connfd << std::endl;
     string content =  resp.first;
     std::string msg = "HTTP/1.1 200 OK\r\nContent-Type:" + resp.second + "\r\nContent-Length: " + std::to_string(content.size()) +"\r\nConnection: close\r\n\r\n" + content;
     _outputBuffer.append(msg.c_str(), msg.size());


### PR DESCRIPTION
As per https://github.com/neutralinojs/neutralinojs/issues/47, removing the debug log messages.

Was able to built the `core-linux` successfully:
```
bash build.sh 
Neutralino is being built..
```

And run it [http://localhost:8080/myapp]:

![image](https://user-images.githubusercontent.com/2962854/46312008-b6ba0280-c5bb-11e8-9025-00002a8f6a58.png)

