### PR TITLE
Add log file support, implement #167.

### DIFF
--- a/core-linux/build.sh
+++ b/core-linux/build.sh
@@ -26,7 +26,7 @@ if [ -e bin/neutralino ]; then
     rm bin/neutralino
 fi
 
-g++ -I ../core-shared -std=c++14 ../core-shared/log.cpp src/Buffer.cpp src/Handler.cpp src/requestparser.cpp src/Socket.cpp src/functions.cpp src/main.cpp src/router.cpp src/core/filesystem/filesystem.cpp src/settings.cpp src/core/os/os.cpp src/core/computer/computer.cpp src/auth/authbasic.cpp src/ping/ping.cpp src/core/storage/storage.cpp src/cloud/previleges.cpp -pthread -std=c++14 -DWEBVIEW_GTK=1 `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -o bin/neutralino -no-pie
+g++ -I ../core-shared -std=c++14 ../core-shared/log.cpp src/Buffer.cpp src/Handler.cpp src/requestparser.cpp src/Socket.cpp src/functions.cpp src/main.cpp src/router.cpp src/core/filesystem/filesystem.cpp src/settings.cpp src/core/os/os.cpp src/core/computer/computer.cpp src/auth/authbasic.cpp src/ping/ping.cpp src/core/storage/storage.cpp src/cloud/previleges.cpp -pthread -std=c++14 -DWEBVIEW_GTK=1 `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -o bin/neutralino -no-pie -lstdc++fs
 
 if [ -e bin/neutralino ]; then 
     echo "Neutralino binary is compiled in to bin/netralino"

--- a/core-shared/log.cpp
+++ b/core-shared/log.cpp
@@ -1,3 +1,34 @@
 #include "log.h"
 
 std::mutex log::_mutex;
+std::atomic<bool> log::_log_to_file (true);
+std::atomic<bool> log::_log_to_stdout (true);
+std::experimental::filesystem::path log::_logfile_path
+    (std::experimental::filesystem::current_path() / "neutralinojs.log");
+
+log::log() :  _lock_guard (_mutex)
+{
+    if (_log_to_file) {
+        _log_file.open("neutralinojs.log", std::ios::app);
+    }
+}
+
+bool log::isLogToLogFileEnabled()
+{
+    return _log_to_file;
+}
+
+bool log::isLogToStdoutEnabled()
+{
+    return _log_to_stdout;
+}
+
+void log::setLogToLogFileEnabled(const bool enabled)
+{
+    _log_to_file = enabled;
+}
+
+void log::setLogToStdoutEnabled(const bool enabled)
+{
+    _log_to_stdout = enabled;
+}

--- a/core-shared/log.h
+++ b/core-shared/log.h
@@ -23,39 +23,94 @@
 #ifndef LOG_H
 #define LOG_H
 
+#include <atomic>
+#include <experimental/filesystem>
+#include <fstream>
 #include <memory>
 #include <mutex>
 #include <iostream>
 
+//! Basic Logging class.
 class log {
 private:
     static std::mutex _mutex;
     std::lock_guard<std::mutex> _lock_guard;
 
-    log() : _lock_guard (_mutex) {}
+    // Path of the logfile. This is set during „init“.
+    static std::experimental::filesystem::path _logfile_path;
+
+    // Handle of the logfile.
+    std::ofstream _log_file;
+
+    //! If this is true, we log to stdout.
+    static std::atomic<bool> _log_to_stdout;
+
+    //! If this is true, we log to a file called „neutralinojs.log“.
+    static std::atomic<bool> _log_to_file;
+
+    log();
 
     log(const log&) = delete;
     log& operator=(const log&) = delete;
     log(log&&) : _lock_guard(_mutex) {}
     log& operator=(log&&) = default;
 
-    
-
 public:
     ~log() {
-        std::cout << "\n";
+        // On destroying the object, we print a newline to stdout and the logfile,
+        // but only if either is enabled.
+        if (isLogToStdoutEnabled()) {
+            std::cout << "\n";
+        }
+
+        if (isLogToLogFileEnabled()) {
+#ifdef _WIN32
+            // For Windows we want to make sure that we got the correct line ending.
+            _log_file << "\r";
+#endif
+            _log_file << "\n";
+        }
     }
 
     template<typename T>
     log& operator <<(const T& val) {
-        std::cout << val;
+        if (isLogToStdoutEnabled()) {
+            std::cout << val;
+        }
+        if (isLogToLogFileEnabled()) {
+            // We use a stringstream to convert val to string. This is more
+            // flexible than calling std::to_string.
+            std::stringstream ss;
+            ss << val;
+            _log_file << ss.str();
+        }
         return *this;
     }
 
     static log Log(const std::string& prefix, const std::string& file, const std::string& func) {
-        std::cout << prefix << " [" + file + ":" + func + "] ";
-        return log();
+        log instance;
+        std::stringstream log_str;
+        log_str << prefix << " [" + file + ":" + func + "] ";
+        if (isLogToStdoutEnabled()) {
+            std::cout << log_str.str();
+        }
+        if (isLogToLogFileEnabled()) {
+            instance._log_file << log_str.str();
+        }
+        return instance;
     }
+
+    //! Enable or disable logging to stdout.
+    static void setLogToStdoutEnabled(const bool enabled);
+
+    //! Returns true if logging to stdout is enabled.
+    static bool isLogToStdoutEnabled();
+
+    //! Enable or disable logging to neutralinojs.log
+    static void setLogToLogFileEnabled(const bool enabled);
+
+    //! Returns true if logging to neutralinojs.log is enabled.
+    static bool isLogToLogFileEnabled();
 };
 
 #define INFO() log::Log("INFO",__FILE__, __func__)

--- a/core-windows/build.bat
+++ b/core-windows/build.bat
@@ -29,7 +29,7 @@ if EXIST bin\neutralino.exe (
     del /f bin\neutralino.exe 
 )
 
-g++ -I ../core-shared ../core-shared/log.cpp src/main.cpp src/settings.cpp src/requestparser.cpp src/serverlistener.cpp src/functions.cpp src/core/computer/computer.cpp src/core/filesystem/filesystem.cpp src/core/os/os.cpp src/router.cpp src/auth/authbasic.cpp src/ping/ping.cpp src/core/storage/storage.cpp src/cloud/previleges.cpp src/webv.cpp -lws2_32 -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -mwindows -Wconversion-null -DWEBVIEW_WINAPI=1 -lole32 -lcomctl32 -loleaut32 -luuid -mwindows -o bin/neutralino 
+g++ -I ../core-shared ../core-shared/log.cpp src/main.cpp src/settings.cpp src/requestparser.cpp src/serverlistener.cpp src/functions.cpp src/core/computer/computer.cpp src/core/filesystem/filesystem.cpp src/core/os/os.cpp src/router.cpp src/auth/authbasic.cpp src/ping/ping.cpp src/core/storage/storage.cpp src/cloud/previleges.cpp src/webv.cpp -lws2_32 -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -mwindows -Wconversion-null -DWEBVIEW_WINAPI=1 -lole32 -lcomctl32 -loleaut32 -luuid -mwindows -o bin/neutralino -lstdc++fs
 
 if EXIST bin\neutralino.exe (
     echo Neutralino binary is compiled in to bin/netralino.exe


### PR DESCRIPTION
Signed-off-by: Philipp Ludwig <git@philippludwig.net>

## Description
This PR adds log file support; as suggested in #167, this will log everything to file called `neutralinojs.log`. Logging to the file and to stdout can be disabled, both is enabled by default.

To realize this, I used the standard C++ filesystem library. If neutralinojs gets ever upgraded to C++17, you should replace the `std::experimental::filesystem` with just `std::filesystem`.

## Changes proposed
The existing logging class is extended with the described feature.

## How to test it
No tests required, since this is fairly simple.

## Next steps
None.

## Deploy notes
On Windows, the lines of the log file will end with `\r\n` to provide better support with default Windows tools such as notepad.