### PR TITLE
Add HighResolution capability for macOS

### DIFF
--- a/core-macos/example/Neut.app/Contents/Info.plist
+++ b/core-macos/example/Neut.app/Contents/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSHighResolutionCapable</key>
+    <true/>
     <key>CFBundleExecutable</key>
     <string>neutralino</string>
     <key>CFBundleGetInfoString</key>
@@ -14,10 +16,10 @@
     <string>Neut</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
This will prevent the app looking fuzzy in a HiDPI/Retina environment on macOS.

### Screenshot Before
<img width="1001" alt="before-hidpi" src="https://user-images.githubusercontent.com/5929807/70891685-7b2a1d80-2033-11ea-8097-b2e6cc37c8d2.png">

### Screenshot After
<img width="1000" alt="after-hidpi" src="https://user-images.githubusercontent.com/5929807/70891706-841aef00-2033-11ea-9721-4a9d0f2cd3da.png">

## Changes proposed
Add `NSHighResolutionCapable` to `Info.plist` file

## How to test it
Open the bundle on a HiDPI macOS desktop or see the screenshots above

## Next steps
None.

## Deploy notes
None.
