### PR TITLE
Update NL_VERSION to 1.2.0

### DIFF
--- a/core-linux/src/settings.cpp
+++ b/core-linux/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Linux';";
-        s += "var NL_VERSION='1.0.8';";
+        s += "var NL_VERSION='1.2.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-macos/src/settings.cpp
+++ b/core-macos/src/settings.cpp
@@ -94,7 +94,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='MacOS(Darwin)';";
-        s += "var NL_VERSION='1.0.8';";
+        s += "var NL_VERSION='1.2.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-windows/src/settings.cpp
+++ b/core-windows/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Windows';";
-        s += "var NL_VERSION='1.0.8';";
+        s += "var NL_VERSION='1.2.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";


### PR DESCRIPTION
## Description
Update the value of NL_VERSION to match the app version.

## Changes proposed
Just the global var in s

## How to test it
Use the NL_VERSION variable in a script,.

## Next steps
I suggest that in the future there be a single source file for setting all the non-OS-specific script constants like NL_VERSION to use.
