### PR TITLE
fix output name in prompt

### DIFF
--- a/core-linux/build.sh
+++ b/core-linux/build.sh
@@ -29,7 +29,7 @@ fi
 g++ -I ../core-shared -std=c++14 ../core-shared/log.cpp src/Buffer.cpp src/Handler.cpp src/requestparser.cpp src/Socket.cpp src/functions.cpp src/main.cpp src/router.cpp src/core/filesystem/filesystem.cpp src/settings.cpp src/core/os/os.cpp src/core/computer/computer.cpp src/core/debug/debug.cpp src/auth/authbasic.cpp src/ping/ping.cpp src/core/storage/storage.cpp src/core/app/app.cpp src/cloud/privileges.cpp -pthread -std=c++14 -DWEBVIEW_GTK=1 `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -o bin/neutralino -no-pie -lstdc++fs
 
 if [ -e bin/neutralino ]; then 
-    echo "Neutralino binary is compiled in to bin/netralino"
+    echo "Neutralino binary is compiled in to bin/neutralino"
 else 
     echo "ERR : Neutralino binary is not compiled"
 fi


### PR DESCRIPTION
## Description
fix output name in the linux build shell script

## Changes proposed
- fixed typo

## How to test it
it is just a typo in the neutralino build script for linux.

## Next steps

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.