### PR TITLE
Macos automated build using shell script

### DIFF
--- a/.github/workflows/cpp_ci.yml
+++ b/.github/workflows/cpp_ci.yml
@@ -10,7 +10,7 @@ jobs:
     - name: configure
       run: sudo apt-get install libgtk-3-dev -y && sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-37 libwebkit2gtk-4.0-dev
     - name: build
-      run: bash build.sh
+      run: bash build.sh linux
 
   build-windows:
     runs-on: windows-latest
@@ -23,9 +23,5 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Configure
-      working-directory: core-macos
-      run: mkdir -p build && cd build && cmake ..
-    - name: Build
-      working-directory: core-macos/build
-      run: cmake --build .
+    - name: Configure & Build
+      run: bash build.sh macos

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Neutralino now supports MacOSX
 - CMake 3.15+
 
 ```bash
-bash build.sh macos
+$ bash build.sh macos
 ```
 
 #### Debug Builds

--- a/README.md
+++ b/README.md
@@ -119,14 +119,23 @@ Neutralino now supports MacOSX
 - Xcode Command Line Tools
 - CMake 3.15+
 
+```bash
+bash build.sh macos
+```
+
 #### Debug Builds
 
 Debug builds are unoptimized fat binaries containing debug information. This is the type you should use for any debugging purpose.
 
+##### Automatically
+- `cd core-macos`
+- `bash build.sh`
+
+##### Manually
 - `mkdir build`
 - `cd build`
 - `cmake ..`
-- `make -j 4`
+- `make -j "$(sysctl -n hw.physicalcpu)"`
 
 The resulting binary will be placed in **build** directory
 
@@ -137,7 +146,7 @@ Release builds are optimized binaries with a very small footprint. Suitable for 
 - `mkdir release`
 - `cd release`
 - `cmake .. -DCMAKE_BUILD_TYPE=Release`
-- `make -j 4`
+- `make -j "$(sysctl -n hw.physicalcpu)"`
 
 The resulting binary will be placed in **release** directory
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 # MIT License
 
-# Copyright (c) 2018 Neutralinojs
+# Copyright (c) 2018-2020 Neutralinojs
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+USER_PLATFORM="$1"
+if [ "$USER_PLATFORM" != linux ] && [ "$USER_PLATFORM" != macos ]
+then
+    echo "Error: platform must be either linux or macos!" 2>&1
+    exit 1
+fi
 
-cd core-linux
+cd "core-$USER_PLATFORM" || exit
 bash build.sh
+
 echo "Building neutralino.js"
-cd ../neutralino.js
+cd ../neutralino.js || exit
+
+if [ ! -d node_modules/ ]
+then
+    npm install
+fi
+
 npm run build
-cp dist/neutralino.js ../core-linux/bin/app/assets/neutralino.js
-cd ..
-cp -r core-linux/bin/* dist/
+cp dist/neutralino.js ../"core-$USER_PLATFORM"/bin/app/assets/neutralino.js
+
+cd .. || exit
+cp -r "core-$USER_PLATFORM"/bin/* dist/

--- a/build.sh
+++ b/build.sh
@@ -33,11 +33,7 @@ bash build.sh
 echo "Building neutralino.js"
 cd ../neutralino.js || exit
 
-if [ ! -d node_modules/ ]
-then
-    npm install
-fi
-
+test ! -d node_modules/ && npm install
 npm run build
 cp dist/neutralino.js ../"core-$USER_PLATFORM"/bin/app/assets/neutralino.js
 

--- a/core-macos/build.sh
+++ b/core-macos/build.sh
@@ -1,0 +1,28 @@
+# MIT License
+
+# Copyright (c) 2018-2020 Neutralinojs
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+if [ -d build ]
+then
+    cmake --build .
+else
+    mkdir -p build && cd build && cmake ..
+fi

--- a/core-macos/build.sh
+++ b/core-macos/build.sh
@@ -25,4 +25,5 @@ then
     cmake --build .
 else
     mkdir -p build && cd build && cmake ..
+    cmake -- build .
 fi

--- a/core-macos/build.sh
+++ b/core-macos/build.sh
@@ -25,7 +25,6 @@ if [ -d build ]
 then 
     cmake --build .
 else
-    mkdir -p build && cd build && cmake ..
-    cmake -- build .
+    mkdir -p build && cd build && cmake .. && cmake -- build .
 fi
 

--- a/core-macos/build.sh
+++ b/core-macos/build.sh
@@ -21,9 +21,10 @@
 # SOFTWARE.
 
 echo "Debug build for MacOSX" 
-mkdir -p build
+test ! -d build && mkdir -p build
 cd build || exit
 cmake ..
-echo $(sysctl -n hw.physicalcpu)
-make -j $(sysctl -n hw.physicalcpu)
+
+echo "Building with max core: $(sysctl -n hw.physicalcpu)"
+make -j "$(sysctl -n hw.physicalcpu)"
 

--- a/core-macos/build.sh
+++ b/core-macos/build.sh
@@ -20,11 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-echo "Debug build for MacOSX"
-if [ -d build ]
-then 
-    cmake --build .
-else
-    mkdir -p build && cd build && cmake .. && cmake -- build .
-fi
+echo "Debug build for MacOSX" 
+mkdir -p build
+cd build || exit
+cmake ..
+echo $(sysctl -n hw.physicalcpu)
+make -j $(sysctl -n hw.physicalcpu)
 

--- a/core-macos/build.sh
+++ b/core-macos/build.sh
@@ -20,10 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+echo "Debug build for MacOSX"
 if [ -d build ]
-then
+then 
     cmake --build .
 else
     mkdir -p build && cd build && cmake ..
     cmake -- build .
 fi
+


### PR DESCRIPTION
## Description
add shell script to build core-macos and njs for macos build. Fixes #215 

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - as stated in the description above

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->

 - This uses the original build.sh in the root directory. Just type bash build.sh linux to build linux build or bash build.sh macos to build macos version

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

Only macos debug build is supported for this PR