### PR TITLE
fix url encoding in routes

### DIFF
--- a/core-windows/src/functions.cpp
+++ b/core-windows/src/functions.cpp
@@ -55,5 +55,23 @@ namespace functions {
         return s;
     }
 
+    string decodeUrl(string &encoded) {
+        string decoded;
+        char c;
+        int i, j;
+
+        for (i = 0; i < encoded.length(); ++i) {
+            if (int(encoded[i]) == 37) {
+                sscanf(encoded.substr(i + 1, 2).c_str(), "%x", &j);
+                c = static_cast<char>(j);
+                decoded += c;
+                i += 2;
+            } else {
+                decoded += encoded[i];
+            }
+        }
+
+        return decoded;
+    }
 
 }

--- a/core-windows/src/functions.h
+++ b/core-windows/src/functions.h
@@ -31,6 +31,7 @@ using namespace std;
 namespace functions {
     vector<string> split(const string &s, char delim);
     string generateToken(int len = 32);
+    string decodeUrl(string &encoded);
 }
 
 #endif // end of FUNCTIONS_H

--- a/core-windows/src/router.cpp
+++ b/core-windows/src/router.cpp
@@ -57,10 +57,11 @@ namespace routes {
         return "<html style=\"width: 100%; height: 100%; position: absolute; background-repeat:no-repeat; background-position: center; background-color: black; background-image:url('" + routes::getIcon() + "')\"></html>";
     }
 
-    pair<string, string> handle(string path, string j, string token) {
+    pair<string, string> handle(string encodedPath, string j, string token) {
         json options = settings::getOptions();
         ping::receivePing();
-        
+        string path = functions::decodeUrl(encodedPath);
+
         string appname = options["appname"];
         if(path == "/" +  appname ){
             return make_pair(settings::getFileContent("app\\index.html"), "text/html");


### PR DESCRIPTION
This is a fix for bug #159.

No special character including spaces is decoded for now in routing. This lays to the default route returning `{"message":"Neutralino"}`.

My solution is to [decode paths](https://en.wikipedia.org/wiki/Percent-encoding) before routing. 