### PR TITLE
Asset path url encoded

### DIFF
--- a/core-macos/src/router.cpp
+++ b/core-macos/src/router.cpp
@@ -29,6 +29,7 @@
 
 #include "nlohmann/json.hpp"
 
+#include "url.h"
 #include "functions.h"
 #include "settings.h"
 #include "core/include/filesystem.h"
@@ -75,6 +76,7 @@ namespace routes {
             {"woff2", "font/woff2"},
             {"mp3", "audio/mpeg"}
         };
+
         if(isBinary)
             return make_pair( settings::getFileContentBinary("app" + path), mimeTypes[extension]);
         else
@@ -82,8 +84,11 @@ namespace routes {
     }
 
    pair<string, string> handle(string path, string j, string token) {
+
         json options = settings::getOptions();
         ping::receivePing();
+
+        path = url::url_decode(path);
         
         string appname = options["appname"];
         bool isAsset = path.find("/assets") != string::npos;
@@ -96,11 +101,11 @@ namespace routes {
         else if(path == "/settings.json"){
             return make_pair(settings::getSettings().dump(), "application/json");
         }
-                else if(isAsset && regex_match(path, regex(".*\\.(js|html|css)$"))) {
-            return getAsset(path); 
+        else if(isAsset && regex_match(path, regex(".*\\.(js|html|css)$"))) {
+            return getAsset(url::url_decode(path)); 
         }
         else if(isAsset && regex_match(path, regex(".*\\.(jpg|png|svg|gif|ico|woff2|mp3)$"))) {
-            return getAsset(path, true); 
+            return getAsset(url::url_decode(path), true); 
         }
         else if(isAsset) {
             return make_pair("{\"error\":\"Unsupported file type!\"}", "application/json");;

--- a/core-macos/src/router.cpp
+++ b/core-macos/src/router.cpp
@@ -88,8 +88,6 @@ namespace routes {
         json options = settings::getOptions();
         ping::receivePing();
 
-        path = url::url_decode(path);
-        
         string appname = options["appname"];
         bool isAsset = path.find("/assets") != string::npos;
         if(path == "/" +  appname ){

--- a/core-macos/src/url.cpp
+++ b/core-macos/src/url.cpp
@@ -1,0 +1,50 @@
+#include <string>
+
+namespace url {
+    std::string url_encode(std::string str){
+        std::string new_str = "";
+        char c;
+        int ic;
+        const char* chars = str.c_str();
+        char bufHex[10];
+        int len = strlen(chars);
+
+        for(int i=0;i<len;i++){
+            c = chars[i];
+            ic = c;
+            // uncomment this if you want to encode spaces with +
+            /*if (c==' ') new_str += '+';   
+            else */if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') new_str += c;
+            else {
+                sprintf(bufHex,"%X",c);
+                if(ic < 16) 
+                    new_str += "%0"; 
+                else
+                    new_str += "%";
+                new_str += bufHex;
+            }
+        }
+        return new_str;
+    }
+
+    std::string url_decode(std::string str){
+        std::string ret;
+        char ch;
+        int i, ii, len = str.length();
+
+        for (i=0; i < len; i++){
+            if(str[i] != '%'){
+                if(str[i] == '+')
+                    ret += ' ';
+                else
+                    ret += str[i];
+            }else{
+                sscanf(str.substr(i + 1, 2).c_str(), "%x", &ii);
+                ch = static_cast<char>(ii);
+                ret += ch;
+                i = i + 2;
+            }
+        }
+        return ret;
+    }
+}

--- a/core-macos/src/url.h
+++ b/core-macos/src/url.h
@@ -1,0 +1,30 @@
+// MIT License
+
+// Copyright (c) 2018 Neutralinojs
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <string>
+
+
+using namespace std;
+
+namespace url {
+    std::string url_encode(std::string str);
+    std::string url_decode(std::string str);
+}


### PR DESCRIPTION
## Description
(Binary) assets would not load on MacOS when they contained spaces, because the spaces were url-encoded. Added URL encode and decode functions, URL decoded the path when requesting an asset.

Fixes #309 

## Changes proposed
 - Added URL decode and encode function in `url` namespace
 - url_decode `path` string variable when router handles the request for an asset