### PR TITLE
allow access to clipboard

### DIFF
--- a/core-shared/webview/webview.h
+++ b/core-shared/webview/webview.h
@@ -337,9 +337,12 @@ WEBVIEW_API int webview_init(struct webview *w) {
                    G_CALLBACK(webview_load_changed_cb), w);
   gtk_container_add(GTK_CONTAINER(w->priv.scroller), w->priv.webview);
 
-  if (w->debug) {
-    WebKitSettings *settings =
+  WebKitSettings *settings =
       webkit_web_view_get_settings(WEBKIT_WEB_VIEW(w->priv.webview));
+
+  webkit_settings_set_javascript_can_access_clipboard (settings, true);
+
+  if (w->debug) {
     webkit_settings_set_enable_write_console_messages_to_stdout(settings, true);
     webkit_settings_set_enable_developer_extras(settings, true);
 


### PR DESCRIPTION
## Description

Since Neutralino apps are local apps, they should be able to paste.

## How to test it

```html
    <div>
        <h2>Clipboard Test</h2>
        <input id='output' />
        <input id='paste' type='button' value='paste' />
        <input id='copy' type='button' value='copy' />
        <script>
            var $ = x => document.querySelector(x)
            var out = $("#output")

            $('#paste').onclick = () => {
                out.focus()
                out.select()
                document.execCommand("paste")
            }
            
            $('#copy').onclick = () => {
                out.select()
                document.execCommand("copy")
            }
        </script>
    </div>
```
