### PR TITLE
Fix more missing features for FreeBSD

### DIFF
--- a/api/app/app.cpp
+++ b/api/app/app.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #include <signal.h>
 #include <unistd.h>
 
@@ -19,7 +19,7 @@ using json = nlohmann::json;
 namespace app {
     
     string exit(json input) {
-        #if defined(__linux__) || defined(__APPLE__)
+        #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         kill(getpid(),SIGINT);
         #elif defined(_WIN32)
         DWORD pid = GetCurrentProcessId();
@@ -47,7 +47,7 @@ namespace app {
     string open(json input) {
         json output;
         string url = input["url"];
-        #if defined(__linux__) 
+        #if defined(__linux__) || defined(__FreeBSD__)
         int status = system(("xdg-open \"" + url + "\"").c_str());
         #elif defined(__APPLE__)
         system(("open \"" + url + "\"").c_str());

--- a/api/computer/computer.cpp
+++ b/api/computer/computer.cpp
@@ -3,7 +3,7 @@
 #if defined(__linux__)
 #include <sys/sysinfo.h>
 
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
@@ -30,13 +30,16 @@ namespace computer {
             { "available", (sys_info.freeram * sys_info.mem_unit) / DIV }
         };
         
-        #elif defined(__APPLE__)
+        #elif defined(__APPLE__) || defined(__FreeBSD__)
         long pages = sysconf(_SC_PHYS_PAGES);
         long page_size = sysconf(_SC_PAGE_SIZE);
 
         int mib[2];
         int64_t physical_memory;
         mib[0] = CTL_HW;
+	#if defined(__FreeBSD__)
+	#define HW_MEMSIZE HW_PHYSMEM
+	#endif
         mib[1] = HW_MEMSIZE;
         size_t length = sizeof(int64_t);
         sysctl(mib, 2, &physical_memory, &length, NULL, 0);

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -11,7 +11,7 @@
 #include <map>
 #include <cstring>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 #define TRAY_APPINDICATOR 1
 
 #elif defined(__APPLE__)
@@ -238,7 +238,7 @@ namespace os {
     }
 
     string showMessageBox(json input) {
-        #if defined(__linux__) || defined (__FreeBSD__)
+        #if defined(__linux__) || defined(__FreeBSD__)
         json output;
         map <string, string> messageTypes = {{"INFO", "info"}, {"WARN", "warning"},
                                             {"ERROR", "error"}, {"QUESTION", "question"}};

--- a/build_freebsd.sh
+++ b/build_freebsd.sh
@@ -28,7 +28,7 @@ c++ resources.cpp \
     -std=c++17 \
     -DELPP_NO_DEFAULT_LOG_FILE=1 \
     -DWEBVIEW_GTK=1 \
-    `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 glib-2.0` \
+    `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 glib-2.0 appindicator3-0.1` \
     -o bin/neutralino-freebsd \
      -I .
 

--- a/lib/tray/tray.h
+++ b/lib/tray/tray.h
@@ -13,7 +13,7 @@ extern "C" {
 struct tray_menu;
 
 struct tray {
-  #if defined(__linux__)
+  #if defined(__linux__) || defined(__FreeBSD__)
   const char *icon = NULL;
   #elif defined(__APPLE__)
   id icon = NULL;


### PR DESCRIPTION
To build neutralino on FreeBSD, install the following packages
```
pkg install -y gtk+-3.0 webkit2gtk-4.0 glib-2.0 appindicator3-0.1
sh build_freebsd.sh
```