### PR TITLE
Removed unused interval parameter

### DIFF
--- a/server/ping.cpp
+++ b/server/ping.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 bool isActive = true;
 
-void setInterval(std::function<void (void)> function,int interval) {
+void setInterval(std::function<void (void)> function) {
     thread pingThread([=]() {
         while(true) {
             std::this_thread::sleep_for(5s);
@@ -37,8 +37,7 @@ namespace ping {
         if(settings::getMode() == "browser") {
             setInterval([]() {
                 pingTick();
-            },
-            10000);
+            });
         }
     }
 


### PR DESCRIPTION
## Description
Removed an unused interval parameter. No references anywhere in the codebase, seems like it was added in error.

## Changes proposed
 - Removed the interval parameter in the function declaration.
 - Removed the "10000" parameter in the function call.

## How to test it
- Check if the pinging system still works?

## Next steps

None.

## Deploy notes

None.