### PR TITLE
#486: Call SetProcessDpiAwarenessContext only when available

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1238,7 +1238,7 @@ public:
       m_window = *(static_cast<HWND *>(window));
     }
 
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+    setDpi();
     ShowWindow(m_window, SW_SHOW);
     UpdateWindow(m_window);
     SetFocus(m_window);
@@ -1332,6 +1332,16 @@ public:
 
 private:
   virtual void on_message(const std::string msg) = 0;
+  
+  void setDpi() {
+    HMODULE user32 = LoadLibraryA("User32.dll");
+    auto func_win10 = reinterpret_cast<decltype(&SetProcessDpiAwarenessContext)>(
+      GetProcAddress(user32, "SetProcessDpiAwarenessContext"));
+    if (func_win10) {
+        // Windows 10+
+        func_win10(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+    }
+  }
 
   HWND m_window;
   POINT m_minsz = POINT{0, 0};


### PR DESCRIPTION
## fix launch failure issue on win7/win8.1

The failure is caused by the fact that SetProcessDpiAwarenessContext function
does not exist in older windows before windows 10.
This fix is merely avoiding calling the function if it does not exist in user32.dll.
Ultimate fix should include calling equivalent functions in older windows.

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - check the existance of the function and call it if available.  Ignore otherwise.
 - split the logic into separate method.  So that it can be extended to support
   older Windows in future.
