### PR TITLE
Prevent cluttering of root folder when building on Windows

### DIFF
--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -56,6 +56,7 @@
         "windows": [
             "/EHsc",
             "/Os",
+            "/Fobin/",
             "/link lib/webview/windows/WebView2Loader.dll.lib"
         ]
     },


### PR DESCRIPTION
## Description
Currently, building on Windows litters the project root with temporary object files. While this is not a problem as object files are ignored, it is slightly annoying to work with when using VS Code.

## Changes proposed
 - Add the `/Fobin/` flag to Windows build options. This puts the object files in the `bin/` folder.

## How to test it
 - Run build using `python scripts/bz.py`. All temporary object files should be in `bin/`.

## Next steps
None.

## Deploy notes
None.