### PR TITLE
Fix broken test suite (Github Actions)

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -8,8 +8,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Install Libraries
       run: |
@@ -41,8 +39,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Build
       run: python ./scripts/bz.py
@@ -53,8 +49,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Build
       run: |

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -10,29 +10,29 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-      
+
     - name: Install Libraries
-      run: | 
+      run: |
         sudo apt-get update
         sudo apt-get install -y -f \
         libgtk-3-dev \
         libwebkit2gtk-4.0-37 \
         libwebkit2gtk-4.0-dev \
-        libayatana-appindicator3-dev 
+        libayatana-appindicator3-dev
         sudo apt-get install -y -f xvfb
-        
+
     - name: Build
       run: |
         ./scripts/bz.py
         chmod +x ./bin/neutralino-linux_x64
-        
+
     - name: Setup Spec Requirements
-      working-directory: ./bin/extensions/sampleextension 
+      working-directory: ./bin/extensions/sampleextension
       run: npm ci
-      
+
     - name: Run Spec
-      working-directory: ./spec 
-      run: | 
+      working-directory: ./spec
+      run: |
         npm ci
         xvfb-run npm run test
 
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-      
+
     - name: Build
       run: python ./scripts/bz.py
       shell: cmd
@@ -55,18 +55,18 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-      
+
     - name: Build
       run: |
         ./scripts/bz.py
         chmod +x ./bin/neutralino-mac_x64
-        
+
     - name: Setup Spec Requirements
-      working-directory: ./bin/extensions/sampleextension 
+      working-directory: ./bin/extensions/sampleextension
       run: npm ci
-      
+
     - name: Run Spec
-      working-directory: ./spec 
-      run: | 
+      working-directory: ./spec
+      run: |
         npm ci
         npm run test

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
       
     - name: Install Libraries
       run: | 
@@ -39,6 +41,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
       
     - name: Build
       run: python ./scripts/bz.py
@@ -49,6 +53,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
       
     - name: Build
       run: |

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -36,7 +36,7 @@ def get_compiler():
     return compilers[BZ_OS] + ' '
 
 def get_latest_commit():
-    return subprocess.getoutput('git log -n 1 origin/main --pretty=format:"%H"') \
+    return subprocess.getoutput('git rev-parse HEAD') \
             .strip()
 
 def apply_template_vars(text):

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -36,7 +36,7 @@ def get_compiler():
     return compilers[BZ_OS] + ' '
 
 def get_latest_commit():
-    return subprocess.getoutput('git log -n 1 main --pretty=format:"%H"') \
+    return subprocess.getoutput('git log -n 1 origin/main --pretty=format:"%H"') \
             .strip()
 
 def apply_template_vars(text):

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -36,8 +36,7 @@ def get_compiler():
     return compilers[BZ_OS] + ' '
 
 def get_latest_commit():
-    return subprocess.getoutput('git rev-parse HEAD') \
-            .strip()
+    return subprocess.getoutput('git rev-parse HEAD').strip()
 
 def apply_template_vars(text):
     return text\


### PR DESCRIPTION
## Description
Currently, the checkout action only fetches a single commit. When the tests run on a branch other than main, then build fails the as `git log ...` command in `bz.py` cannot find the main branch locally (as it does not exist on the CI machine).

This can be seen in:
- https://github.com/neutralinojs/neutralinojs/runs/6112616322?check_suite_focus=true
- https://github.com/neutralinojs/neutralinojs/runs/6141133611?check_suite_focus=true

If you check the output of the build step in theses links (scroll up), you can see that the error message by `git log` is mixed with the build command, causing the build to fail.

## Changes proposed
Fetch all branches by using `fetch-depth: 0`.

EDIT: Also get commit hash from `origin/main` instead of `main`.

## How to test it
Try running any CI tests after this change is merged.

## Next steps
None.

## Deploy notes
None.