### PR TITLE
[WIP]: Update filesystem.getStats(path) to fetch last modified time

### DIFF
--- a/api/filesystem/filesystem.cpp
+++ b/api/filesystem/filesystem.cpp
@@ -14,6 +14,12 @@
 #include <atlstr.h>
 #include <shlwapi.h>
 #include <winbase.h>
+#define WINDOWS_TICK 10000000
+#define SEC_TO_UNIX_EPOCH 11644473600LL
+long long WindowsTickToUnixMilliSeconds(long long windowsTicks)
+{   long long unixTime = (windowsTicks / WINDOWS_TICK - SEC_TO_UNIX_EPOCH)*1000;
+    return unixTime;
+}
 #endif
 
 #include "lib/json/json.hpp"
@@ -135,6 +141,8 @@ fs::FileStats getStats(const string &path) {
         fileStats.size = size.QuadPart;
         fileStats.isFile = !(basicInfo.FileAttributes & FILE_ATTRIBUTE_DIRECTORY);
         fileStats.isDirectory = basicInfo.FileAttributes & FILE_ATTRIBUTE_DIRECTORY;
+        fileStats.createdAt = WindowsTickToUnixMilliSeconds(basicInfo.CreationTime.QuadPart);
+        fileStats.modifiedAt = WindowsTickToUnixMilliSeconds(basicInfo.ChangeTime.QuadPart);
     }
 
     #endif

--- a/api/filesystem/filesystem.cpp
+++ b/api/filesystem/filesystem.cpp
@@ -118,6 +118,8 @@ fs::FileStats getStats(const string &path) {
         fileStats.size = statBuffer.st_size;
         fileStats.isFile = S_ISREG(statBuffer.st_mode);
         fileStats.isDirectory = S_ISDIR(statBuffer.st_mode);
+        fileStats.createdAt = statBuffer.st_ctime;
+        fileStats.modifiedAt = statBuffer.st_mtime;
     }
 
     #elif defined(_WIN32)
@@ -419,6 +421,8 @@ json getStats(const json &input) {
         stats["size"] = fileStats.size;
         stats["isFile"] = fileStats.isFile;
         stats["isDirectory"] = fileStats.isDirectory;
+        stats["createdAt"] = fileStats.createdAt;
+        stats["modifiedAt"] = fileStats.modifiedAt;
         output["returnValue"] = stats;
         output["success"] = true;
     }

--- a/api/filesystem/filesystem.cpp
+++ b/api/filesystem/filesystem.cpp
@@ -118,8 +118,8 @@ fs::FileStats getStats(const string &path) {
         fileStats.size = statBuffer.st_size;
         fileStats.isFile = S_ISREG(statBuffer.st_mode);
         fileStats.isDirectory = S_ISDIR(statBuffer.st_mode);
-        fileStats.createdAt = statBuffer.st_ctime;
-        fileStats.modifiedAt = statBuffer.st_mtime;
+        fileStats.createdAt = statBuffer.st_ctime*1000;
+        fileStats.modifiedAt = statBuffer.st_mtime*1000;
     }
 
     #elif defined(_WIN32)

--- a/api/filesystem/filesystem.h
+++ b/api/filesystem/filesystem.h
@@ -27,8 +27,8 @@ struct FileStats {
     long long size;
     bool isDirectory;
     bool isFile;
-    time_t createdAt;
-    time_t modifiedAt;
+    long long createdAt;
+    long long modifiedAt;
 };
 
 bool createDirectory(const string &path);

--- a/api/filesystem/filesystem.h
+++ b/api/filesystem/filesystem.h
@@ -2,7 +2,6 @@
 #define NEU_FILESYSTEM_H
 
 #include <string>
-
 #include "lib/json/json.hpp"
 
 using json = nlohmann::json;
@@ -28,6 +27,8 @@ struct FileStats {
     long long size;
     bool isDirectory;
     bool isFile;
+    time_t createdAt;
+    time_t modifiedAt;
 };
 
 bool createDirectory(const string &path);


### PR DESCRIPTION
Fixes #876 
[WIP]

Update `filesystem.getStats()` function to return last modified time and created time in seconds when called.

To test call the following function:

```
async function displayGetStats() {
    try{
    let stats = await Neutralino.filesystem.getStats('path_to_file');
    console.log('Stats:', stats);
    }
    catch(e){
        console.log(e);
    }
}
displayGetStats();
```