### PR TITLE
Hidden folder attribute

### DIFF
--- a/api/storage/storage.cpp
+++ b/api/storage/storage.cpp
@@ -8,6 +8,10 @@
 #include "helpers.h"
 #include "api/filesystem/filesystem.h"
 
+#if defined(_WIN32)
+#include <fileapi.h>
+#endif
+
 #define STORAGE_DIR "/.storage"
 #define STORAGE_EXT ".neustorage"
 #define STORAGE_KEY_REGEX "^[a-zA-Z-_0-9]{1,50}$"
@@ -66,6 +70,9 @@ json setData(const json &input) {
     string bucketPath = settings::joinAppPath(STORAGE_DIR);
 
     fs::createDirectory(bucketPath);
+    #if defined(_WIN32)
+    SetFileAttributesA(bucketPath.c_str(), FILE_ATTRIBUTE_HIDDEN); // Set Hidden Attribute to the folder on windows
+    #endif
 
     string filename = bucketPath + "/" + key + STORAGE_EXT;
     if(!helpers::hasField(input, "data")) {

--- a/api/storage/storage.cpp
+++ b/api/storage/storage.cpp
@@ -72,7 +72,7 @@ json setData(const json &input) {
 
     fs::createDirectory(bucketPath);
     #if defined(_WIN32)
-    SetFileAttributesA(bucketPath.c_str(), FILE_ATTRIBUTE_HIDDEN); // Set Hidden Attribute to the folder on windows
+    SetFileAttributesA(bucketPath.c_str(), FILE_ATTRIBUTE_HIDDEN);
     #endif
 
     string filename = bucketPath + "/" + key + STORAGE_EXT;

--- a/api/storage/storage.cpp
+++ b/api/storage/storage.cpp
@@ -9,6 +9,7 @@
 #include "api/filesystem/filesystem.h"
 
 #if defined(_WIN32)
+#include <windows.h>
 #include <fileapi.h>
 #endif
 


### PR DESCRIPTION
## Description
This PR adds a simple functionality, which is setting the Hidden attribute flag on windows to the `.storage` folder, on Linux any file/folder starting with a period is automatically hidden, but on windows you need to set that flag.

## Changes proposed
- `api/storage/storage.cpp`: Uses [`SetFileAttributes`](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesa) Function from [`Fileapi.h`](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/) To Set The Hidden Flag of the newly created `.storage` folder.

## How to test it
 - Use the [Storage API](https://neutralino.js.org/docs/api/storage/)

## Next steps
None.

## Deploy notes
None.