### PR TITLE
Add ability to set default path and filename on Neutralino.os methods like showSaveDialog()

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -322,6 +322,7 @@ json getEnv(const json &input) {
 json showOpenDialog(const json &input) {
     json output;
     string title = "Open a file";
+    string defaultPath = "";
     vector <string> filters = {"All files", "*"};
     pfd::opt option = pfd::opt::none;
 
@@ -356,6 +357,7 @@ json showOpenDialog(const json &input) {
 json showFolderDialog(const json &input) {
     json output;
     string title = "Select a folder";
+    string defaultPath = "";
 
     if(helpers::hasField(input, "title")) {
         title = input["title"].get<string>();

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -367,6 +367,7 @@ json showFolderDialog(const json &input) {
 json showSaveDialog(const json &input) {
     json output;
     string title = "Save a file";
+    string defaultPath = "";
     vector <string> filters = {"All files", "*"};
     pfd::opt option = pfd::opt::none;
 
@@ -383,7 +384,11 @@ json showSaveDialog(const json &input) {
         filters = __extensionsToVector(input["filters"]);
     }
 
-    string selectedEntry = pfd::save_file(title, "", filters, option).result();
+    if(helpers::hasField(input, "defaultPath")) {
+        defaultPath = input["defaultPath"].get<string>();
+    }
+
+    string selectedEntry = pfd::save_file(title, defaultPath, filters, option).result();
 
     output["returnValue"] = helpers::normalizePath(selectedEntry);
     output["success"] = true;

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -337,8 +337,12 @@ json showOpenDialog(const json &input) {
         filters.clear();
         filters = __extensionsToVector(input["filters"]);
     }
+    
+    if(helpers::hasField(input, "defaultPath")) {
+        defaultPath = input["defaultPath"].get<string>();
+    }
 
-    vector<string> selectedEntries = pfd::open_file(title, "", filters, option).result();
+    vector<string> selectedEntries = pfd::open_file(title, defaultPath, filters, option).result();
 
     for(string &entry: selectedEntries) {
         entry = helpers::normalizePath(entry);
@@ -356,8 +360,12 @@ json showFolderDialog(const json &input) {
     if(helpers::hasField(input, "title")) {
         title = input["title"].get<string>();
     }
+    
+    if(helpers::hasField(input, "defaultPath")) {
+        defaultPath = input["defaultPath"].get<string>();
+    }
 
-    string selectedEntry = pfd::select_folder(title, "", pfd::opt::none).result();
+    string selectedEntry = pfd::select_folder(title, defaultPath, pfd::opt::none).result();
 
     output["returnValue"] = helpers::normalizePath(selectedEntry);
     output["success"] = true;


### PR DESCRIPTION
I've made a small change to showSaveDialog that allows you to specify an option called `defaultPath`. This can be used for both setting a default directory like this:

```javascript
let entry = await Neutralino.os.showSaveDialog('Open a file', {
  filters: [
    {name: 'Images', extensions: ['jpg', 'png']},
    {name: 'All files', extensions: ['*']}
  ],
  defaultPath: '/home/my/directory/'
});
console.log('You have selected:', entry);
```

and a default filename like this:

```javascript
let entry = await Neutralino.os.showSaveDialog('Open a file', {
  filters: [
    {name: 'Images', extensions: ['jpg', 'png']},
    {name: 'All files', extensions: ['*']}
  ],
  defaultPath: '/home/my/directory/untitled.jpg'
});
console.log('You have selected:', entry);
```

I did submit and close a previous PR that tried to do further modification, but I opened this instead after discussing how the lib worked with the original author. It appears doing it this way would make things work across all systems that portable-file-dialogs supports, so is the better option.

Please let me know if you need me to adjust anything. And thanks for your consideration.

Koda