### PR TITLE
Fix #930

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -342,8 +342,8 @@ void __createWindow() {
     if(windowProps.maximize)
         window::maximize();
 
-    if(windowProps.hidden)
-        window::hide();
+    if(!windowProps.hidden)
+        window::show();
 
     if(windowProps.fullScreen)
         window::setFullScreen();

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1285,9 +1285,10 @@ public:
     }
 
     setDpi();
-    ShowWindow(m_window, SW_SHOW);
-    UpdateWindow(m_window);
-    SetFocus(m_window);
+    ShowWindow(m_window, SW_HIDE);
+    // ShowWindow(m_window, SW_SHOW);
+    // UpdateWindow(m_window);
+    // SetFocus(m_window);
 
     auto cb =
         std::bind(&win32_edge_engine::on_message, this, std::placeholders::_1);


### PR DESCRIPTION
**:warning: Not Complete, Under Development :warning:**

## Description
- `lib/webview/webview.h` - Hide The Window By Default
- `api/window/window.cpp` - Show The Window (If `hidden` is set to false in config` Because it is hidden by default.

## How to test it
- Set The Hidden Property in Configuration To `true`
- Launch The Program

## Bugs
- After Window is Shown using `window.show` API, nothing is rendered Except White Screen.