### PR TITLE
Remove --enable-automation Chrome flag to fix #915.

### DIFF
--- a/chrome.cpp
+++ b/chrome.cpp
@@ -41,7 +41,6 @@ string __getDefaultChromeArgs() {
     "--no-first-run "
     "--no-default-browser-check "
     "--safebrowsing-disable-auto-update "
-    "--enable-automation "
     "--password-store=basic "
     "--use-mock-keychain";
 }


### PR DESCRIPTION
This PR removes the `--enable-automation` Chrome flag.
This removes the "Chrome is being controlled by automated test software" infobar.
This fixes issue #915.

