### PR TITLE
Fix popup issue in windows when hidden set to true.

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -143,10 +143,12 @@ bool isVisible() {
 
 bool isFakeHidden() {
     //ensureOnScreen
+    #if defined(_WIN32)
     RECT rect = { NULL };
     if(GetWindowRect( windowHandle, &rect)) {
         return rect.left > 9999;
     }
+    #endif
     return false;
 }
 

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1276,7 +1276,7 @@ public:
             return 0;
           });
       RegisterClassEx(&wc);
-      m_window = CreateWindow("Neutralinojs_webview", "", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+      m_window = CreateWindow("Neutralinojs_webview", "", WS_OVERLAPPEDWINDOW, 99999999 /* CW_USEDEFAULT */,
                               CW_USEDEFAULT, 640, 480, nullptr, nullptr,
                               GetModuleHandle(nullptr), nullptr);
       SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
@@ -1287,6 +1287,14 @@ public:
     setDpi();
     ShowWindow(m_window, SW_SHOW);
     UpdateWindow(m_window);
+    
+    // store the original initial window style
+    m_originalStyleEx = GetWindowLong(m_window, GWL_EXSTYLE);
+    // stop the taskbar icon from showing by changing windowstyle to toolwindow.
+    ShowWindow(m_window, SW_HIDE);
+	  SetWindowLong(m_window, GWL_EXSTYLE, WS_EX_TOOLWINDOW);
+	  ShowWindow(m_window, SW_SHOW);
+    
     SetFocus(m_window);
 
     auto cb =
@@ -1375,6 +1383,8 @@ public:
   void navigate(const std::string url) { m_browser->navigate(url); }
   void eval(const std::string js) { m_browser->eval(js); }
   void init(const std::string js) { m_browser->init(js); }
+
+  DWORD m_originalStyleEx;
 
 private:
   virtual void on_message(const std::string msg) = 0;

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1384,7 +1384,9 @@ public:
   void eval(const std::string js) { m_browser->eval(js); }
   void init(const std::string js) { m_browser->init(js); }
 
+  #if defined(_WIN32)
   DWORD m_originalStyleEx;
+  #endif
 
 private:
   virtual void on_message(const std::string msg) = 0;


### PR DESCRIPTION
## Description
On Windows if you launch Neutralino with `hidden: true` in the config. A window appears for a split second before disappearing. Quite a few people have expressed a wish to have this changed so that the window never appears with this setting, so this pull request introduces a solution that should work given the conditions.

I tested a lot of solutions before hand. Ideally using SW_HIDE when the window is first created would be the solution, however if you do that, the WebView component always fails to load, with a corrupt connection to it's developer tools.

## Changes proposed
The changes made in this pull request are all scoped specifically for Windows using `#if defined(_WIN32)` when needed:

- Set the X coordinate to a crazy high number when CreateWindow is called.
- Change the ex window style to WS_EX_TOOLWINDOW so that no icon appears in the taskbar.
- Provide two helper methods called `window::isFakeHidden()` and  `window::undoFakeHidden()`.

If the window didn't need to hide, or show() is called, the helper methods above provide a way to show the window again to the user.

## How to test it
Build and use the new binary, everything should work as normal, however when you set hidden to true, there will no longer be a window flashing before it hides.