### PR TITLE
Fix build for Apple Silicon

### DIFF
--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -78,8 +78,7 @@
         ],
         "darwin": [
             "WEBVIEW_COCOA=1",
-            "TRAY_APPKIT=1",
-            "OBJC_OLD_DISPATCH_PROTOTYPES=1"
+            "TRAY_APPKIT=1"
         ],
         "windows": [
             "_WEBSOCKETPP_CPP11_STL_",

--- a/lib/tray/tray.h
+++ b/lib/tray/tray.h
@@ -178,31 +178,53 @@ static id statusItem;
 static id statusBarButton;
 
 static id _tray_menu(struct tray_menu *m) {
-    id menu = objc_msgSend((id)objc_getClass("NSMenu"), sel_registerName("new"));
-    objc_msgSend(menu, sel_registerName("autorelease"));
-    objc_msgSend(menu, sel_registerName("setAutoenablesItems:"), false);
+  id menu = ((id (*)(id, SEL))objc_msgSend)(
+          (id)objc_getClass("NSMenu"),
+          sel_registerName("new"));
 
-    for (; m != NULL && m->text != NULL; m++) {
-      if (strcmp(m->text, "-") == 0) {
-        objc_msgSend(menu, sel_registerName("addItem:"),
-          objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("separatorItem")));
-      } else {
-        id menuItem = objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
-        objc_msgSend(menuItem, sel_registerName("autorelease"));
-        objc_msgSend(menuItem, sel_registerName("initWithTitle:action:keyEquivalent:"),
-                  objc_msgSend((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), m->text),
-                  sel_registerName("menuCallback:"),
-                  objc_msgSend((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), ""));
+  ((id (*)(id, SEL))objc_msgSend)(menu, sel_registerName("autorelease"));
+  ((id (*)(id, SEL, bool))objc_msgSend)(menu, sel_registerName("setAutoenablesItems:"), false);
 
-        objc_msgSend(menuItem, sel_registerName("setEnabled:"), (m->disabled ? false : true));
-          objc_msgSend(menuItem, sel_registerName("setState:"), (m->checked ? 1 : 0));
-          objc_msgSend(menuItem, sel_registerName("setRepresentedObject:"),
-            objc_msgSend((id)objc_getClass("NSValue"), sel_registerName("valueWithPointer:"), m));
+  for (; m != NULL && m->text != NULL; m++) {
+    if (strcmp(m->text, "-") == 0) {
+      id separatorItem = ((id (*)(id, SEL))objc_msgSend)(
+              (id)objc_getClass("NSMenuItem"),
+              sel_registerName("separatorItem"));
 
-          objc_msgSend(menu, sel_registerName("addItem:"), menuItem);
+      ((id (*)(id, SEL, id))objc_msgSend)(
+          menu,
+          sel_registerName("addItem:"),
+          separatorItem);
+    } else {
+      id menuItem = ((id (*)(id, SEL))objc_msgSend)(
+              (id)objc_getClass("NSMenuItem"),
+              sel_registerName("alloc"));
 
-          if (m->submenu != NULL) {
-            objc_msgSend(menu, sel_registerName("setSubmenu:forItem:"), _tray_menu(m->submenu), menuItem);
+      ((id (*)(id, SEL))objc_msgSend)(menuItem, sel_registerName("autorelease"));
+
+      ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(
+          menuItem,
+          sel_registerName("initWithTitle:action:keyEquivalent:"),
+          ((id (*)(id, SEL, const char *))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), m->text),
+          sel_registerName("menuCallback:"),
+          ((id (*)(id, SEL, const char *))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), ""));
+
+      ((id (*)(id, SEL, bool))objc_msgSend)(menuItem, sel_registerName("setEnabled:"), (m->disabled ? false : true));
+      ((id (*)(id, SEL, bool))objc_msgSend)(menuItem, sel_registerName("setState:"), (m->checked ? 1 : 0));
+
+      ((id (*)(id, SEL, id))objc_msgSend)(
+          menuItem,
+          sel_registerName("setRepresentedObject:"),
+          ((id (*)(id, SEL, void*))objc_msgSend)((id)objc_getClass("NSValue"), sel_registerName("valueWithPointer:"), m));
+
+      ((id (*)(id, SEL, id))objc_msgSend)(menu, sel_registerName("addItem:"), menuItem);
+
+      if (m->submenu != NULL) {
+        ((id (*)(id, SEL, id, id))objc_msgSend)(
+            menu,
+            sel_registerName("setSubmenu:forItem:"),
+            _tray_menu(m->submenu),
+            menuItem);
       }
     }
   }
@@ -211,69 +233,102 @@ static id _tray_menu(struct tray_menu *m) {
 }
 
 static void menu_callback(id self, SEL cmd, id sender) {
-  struct tray_menu *m =
-      (struct tray_menu *)objc_msgSend(objc_msgSend(sender, sel_registerName("representedObject")),
-                  sel_registerName("pointerValue"));
+  struct tray_menu *m = ((struct tray_menu *(*)(id, SEL))objc_msgSend)(
+      ((id (*)(id, SEL))objc_msgSend)(sender, sel_registerName("representedObject")),
+      sel_registerName("pointerValue"));
 
-    if (m != NULL && m->cb != NULL) {
-      m->cb(m);
-    }
+  if (m != NULL && m->cb != NULL) {
+    m->cb(m);
+  }
 }
 
 static int tray_init(struct tray *tray) {
-    pool = objc_msgSend((id)objc_getClass("NSAutoreleasePool"),
-                          sel_registerName("new"));
+  pool = ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSAutoreleasePool"),
+      sel_registerName("new"));
 
-    objc_msgSend((id)objc_getClass("NSApplication"),
-                          sel_registerName("sharedApplication"));
+  ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSApplication"),
+      sel_registerName("sharedApplication"));
 
-    Class trayDelegateClass = objc_allocateClassPair(objc_getClass("NSObject"), "Tray", 0);
-    class_addProtocol(trayDelegateClass, objc_getProtocol("NSApplicationDelegate"));
-    class_addMethod(trayDelegateClass, sel_registerName("menuCallback:"), (IMP)menu_callback, "v@:@");
-    objc_registerClassPair(trayDelegateClass);
+  Class trayDelegateClass = objc_allocateClassPair(objc_getClass("NSObject"), "Tray", 0);
+  class_addProtocol(trayDelegateClass, objc_getProtocol("NSApplicationDelegate"));
+  class_addMethod(trayDelegateClass, sel_registerName("menuCallback:"), (IMP)menu_callback, "v@:@");
+  objc_registerClassPair(trayDelegateClass);
 
-    id trayDelegate = objc_msgSend((id)trayDelegateClass,
-                          sel_registerName("new"));
+  id trayDelegate = ((id (*)(id, SEL))objc_msgSend)(
+      (id)trayDelegateClass,
+      sel_registerName("new"));
 
-    app = objc_msgSend((id)objc_getClass("NSApplication"),
-                          sel_registerName("sharedApplication"));
+  app = ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSApplication"),
+      sel_registerName("sharedApplication"));
 
-    objc_msgSend(app, sel_registerName("setDelegate:"), trayDelegate);
+  ((id (*)(id, SEL, id))objc_msgSend)(
+      app,
+      sel_registerName("setDelegate:"),
+      trayDelegate);
 
-    statusBar = objc_msgSend((id)objc_getClass("NSStatusBar"),
-                          sel_registerName("systemStatusBar"));
+  statusBar = ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSStatusBar"),
+      sel_registerName("systemStatusBar"));
 
-    statusItem = objc_msgSend(statusBar, sel_registerName("statusItemWithLength:"), -1.0);
+  statusItem = ((id (*)(id, SEL, double))objc_msgSend)(
+      statusBar,
+      sel_registerName("statusItemWithLength:"),
+      -1.0);
 
-    objc_msgSend(statusItem, sel_registerName("retain"));
-    objc_msgSend(statusItem, sel_registerName("setHighlightMode:"), true);
-    statusBarButton = objc_msgSend(statusItem, sel_registerName("button"));
-    tray_update(tray);
-    objc_msgSend(app, sel_registerName("activateIgnoringOtherApps:"), true);
-    return 0;
+  ((id (*)(id, SEL))objc_msgSend)(statusItem, sel_registerName("retain"));
+  ((id (*)(id, SEL, bool))objc_msgSend)(statusItem, sel_registerName("setHighlightMode:"), true);
+
+  statusBarButton = ((id (*)(id, SEL))objc_msgSend)(statusItem, sel_registerName("button"));
+
+  tray_update(tray);
+
+  ((id (*)(id, SEL, bool))objc_msgSend)(
+      app,
+      sel_registerName("activateIgnoringOtherApps:"),
+      true);
+
+  return 0;
 }
 
 static int tray_loop(int blocking) {
-    id until = (blocking ?
-      objc_msgSend((id)objc_getClass("NSDate"), sel_registerName("distantFuture")) :
-      objc_msgSend((id)objc_getClass("NSDate"), sel_registerName("distantPast")));
+ id until = blocking
+     ? ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSDate"), sel_registerName("distantPast"))
+     : ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSDate"), sel_registerName("distantFuture"));
 
-    id event = objc_msgSend(app, sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"),
-                ULONG_MAX,
-                until,
-                objc_msgSend((id)objc_getClass("NSString"),
-                  sel_registerName("stringWithUTF8String:"),
-                  "kCFRunLoopDefaultMode"),
-                true);
-    if (event) {
-      objc_msgSend(app, sel_registerName("sendEvent:"), event);
-    }
-    return 0;
+ id event = ((id (*)(id, SEL, unsigned long, id, id, bool))objc_msgSend)(
+     app,
+     sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"),
+     ULONG_MAX,
+     until,
+     ((id (*)(id, SEL, const char*))objc_msgSend)(
+         (id)objc_getClass("NSString"),
+         sel_registerName("stringWithUTF8String:"),
+         "kCFRunLoopDefaultMode"),
+     true);
+
+ if (event) {
+   ((id (*)(id, SEL, id))objc_msgSend)(
+       app,
+       sel_registerName("sendEvent:"),
+       event);
+ }
+
+ return 0;
 }
 
 static void tray_update(struct tray *tray) {
-  objc_msgSend(statusBarButton, sel_registerName("setImage:"), tray->icon);
-  objc_msgSend(statusItem, sel_registerName("setMenu:"), _tray_menu(tray->menu));
+  ((id (*)(id, SEL, id))objc_msgSend)(
+      statusBarButton,
+      sel_registerName("setImage:"),
+      tray->icon);
+
+  ((id (*)(id, SEL, id))objc_msgSend)(
+      statusItem,
+      sel_registerName("setMenu:"),
+      _tray_menu(tray->menu));
 }
 
 static void tray_exit() {}

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -17,7 +17,7 @@ BZ_ISDARWIN = BZ_OS == 'darwin'
 BZ_ISWIN = BZ_OS == 'windows'
 BZ_ISVERBOSE = '--verbose' in sys.argv
 
-def get_arch(short_names = True, use_mac_rosetta = True):
+def get_arch(short_names = True, use_mac_rosetta = False):
     arch = platform.machine().lower()
 
     if BZ_ISDARWIN and arch == 'arm64' and use_mac_rosetta:
@@ -28,10 +28,10 @@ def get_arch(short_names = True, use_mac_rosetta = True):
 
     if short_names and (arch in ['aarch64']):
         arch = 'arm64'
-    
+
     if short_names and (arch in ['armv7l']):
         arch = 'armhf'
-    
+
     return arch
 
 def get_os_shortname():


### PR DESCRIPTION
## Description

The Apple Silicon (`arm64`) version of the Apple macOS SDK forces all occurrences of `obc_msgSend` to be cast so that the parameter and return types match the call.

https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html

The Neutralino.js codebase does these `obc_msgSend` casts in most places already, but they are missing in `tray.h`. As a consequence, the code does not compile with `macos-arm64` as the target.

## Changes proposed

Change all `objc_msgSend` calls in `tray.h` to cast the function to the right type first.

```c
// Before:
objc_msgSend(menu, sel_registerName("autorelease"));
objc_msgSend(menu, sel_registerName("setAutoenablesItems:"), false);

// After:
((id (*)(id, SEL))objc_msgSend)(menu, sel_registerName("autorelease"));
((id (*)(id, SEL, bool))objc_msgSend)(menu, sel_registerName("setAutoenablesItems:"), false);
```

## How to test it

Right now, `scripts/bz.py` always does an Intel build, even when run on an Apple Silicon machine (see [codrezri/buildzri#7](https://github.com/codezri/buildzri/issues/7)). But you can force an Apple Silicon build by editing the script:

1. Open `scripts/bz.py` in your editor.
2. Find the `get_arch()` function.
3. Change `use_mac_rosetta = True` to `use_mac_rosetta = False`.
4. Run `python scripts/bz.py`.

## Notes

The formatting of `tray.h` seemed quite inconsistent (e.g., indentation varied between 2 and 4 spaces, often within the same function). As two-space indentation and four-space continuaition lines seemed like the most common convention in the file, I changed all functions I touched to be formatted the same.

## Next steps

- We should allow doing an Apple Silicon build without editing the build script. 
- If possible, we could pre-compile Apple Silicon binaries through GitHub Actions.