### PR TITLE
Add cross-compile support for macOS and create universal binary (ARM for Apple Silicon M1 / M2 + x86_64 for Intel based mac)

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -82,12 +82,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build
-      run: ./scripts/bz.py
+      run: |
+        ./scripts/bz.py --target_arch x64
+        ./scripts/bz.py --target_arch arm64
+        lipo bin/neutralino-mac_x64 bin/neutralino-mac_arm64 -create -output bin/neutralino-mac_universal
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: darwin_binary
-        path: bin/neutralino-mac_x64
+        path: |
+          bin/neutralino-mac_x64
+          bin/neutralino-mac_arm64
+          bin/neutralino-mac_universal
         
   create-release:
     needs: [build-linux, build-windows, build-darwin]
@@ -129,7 +135,7 @@ jobs:
     - name: Create Release zip
       uses: vimtor/action-zip@v1
       with:
-        files: ./bin/neutralino-linux_x64 ./bin/neutralino-linux_arm64 ./bin/neutralino-linux_armhf ./bin/neutralino-win_x64.exe ./bin/neutralino-mac_x64 ./bin/WebView2Loader.dll
+        files: ./bin/neutralino-linux_x64 ./bin/neutralino-linux_arm64 ./bin/neutralino-linux_armhf ./bin/neutralino-win_x64.exe ./bin/neutralino-mac_x64 ./bin/neutralino-mac_arm64 ./bin/neutralino-mac_universal ./bin/WebView2Loader.dll
         dest: './bin/neutralinojs-v${{github.event.inputs.version}}.zip'
         
     - name: Create Release Notes

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -80,12 +80,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build
-      run: ./scripts/bz.py
+      run: |
+        ./scripts/bz.py --target_arch x64
+        ./scripts/bz.py --target_arch arm64
+        lipo bin/neutralino-mac_x64 bin/neutralino-mac_arm64 -create -output bin/neutralino-mac_universal
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: darwin_binary
-        path: bin/neutralino-mac_x64
+        path: |
+          bin/neutralino-mac_x64
+          bin/neutralino-mac_arm64
+          bin/neutralino-mac_universal
         
   update-nightly-release:
     needs: [build-linux, build-windows, build-darwin]
@@ -134,7 +140,7 @@ jobs:
     - name: Create Release zip
       uses: vimtor/action-zip@v1
       with:
-        files: ./bin/neutralino-linux_x64 ./bin/neutralino-linux_arm64 ./bin/neutralino-linux_armhf ./bin/neutralino-win_x64.exe ./bin/neutralino-mac_x64 ./bin/WebView2Loader.dll
+        files: ./bin/neutralino-linux_x64 ./bin/neutralino-linux_arm64 ./bin/neutralino-linux_armhf ./bin/neutralino-win_x64.exe ./bin/neutralino-mac_x64 ./bin/neutralino-mac_arm64 ./bin/neutralino-mac_universal ./bin/WebView2Loader.dll
         dest: './bin/neutralinojs-nightly.zip'
         
     - name: Create Release Notes

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Build
       run: |
-        ./scripts/bz.py
+        ./scripts/bz.py --target_arch x64
         chmod +x ./bin/neutralino-mac_x64
 
     - name: Setup Spec Requirements

--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -2,7 +2,7 @@
     "std": "c++17",
     "name": "Neutralinojs",
     "version": "4.9.0",
-    "output": "./bin/neutralino-${BZ_OS}_${BZ_ARCH}",
+    "output": "./bin/neutralino-${BZ_OS}_${BZ_TARGET_ARCH}",
     "include": {
         "*": [
             ".",
@@ -49,7 +49,6 @@
             "-Os"
         ],
         "darwin": [
-            "-arch ${BZ_ARCHL}",
             "-Wno-deprecated-declarations",
             "-framework WebKit",
             "-framework Cocoa",

--- a/lib/tray/tray.h
+++ b/lib/tray/tray.h
@@ -178,31 +178,53 @@ static id statusItem;
 static id statusBarButton;
 
 static id _tray_menu(struct tray_menu *m) {
-    id menu = objc_msgSend((id)objc_getClass("NSMenu"), sel_registerName("new"));
-    objc_msgSend(menu, sel_registerName("autorelease"));
-    objc_msgSend(menu, sel_registerName("setAutoenablesItems:"), false);
+  id menu = ((id (*)(id, SEL))objc_msgSend)(
+          (id)objc_getClass("NSMenu"),
+          sel_registerName("new"));
 
-    for (; m != NULL && m->text != NULL; m++) {
-      if (strcmp(m->text, "-") == 0) {
-        objc_msgSend(menu, sel_registerName("addItem:"),
-          objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("separatorItem")));
-      } else {
-        id menuItem = objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
-        objc_msgSend(menuItem, sel_registerName("autorelease"));
-        objc_msgSend(menuItem, sel_registerName("initWithTitle:action:keyEquivalent:"),
-                  objc_msgSend((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), m->text),
-                  sel_registerName("menuCallback:"),
-                  objc_msgSend((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), ""));
+  ((id (*)(id, SEL))objc_msgSend)(menu, sel_registerName("autorelease"));
+  ((id (*)(id, SEL, bool))objc_msgSend)(menu, sel_registerName("setAutoenablesItems:"), false);
 
-        objc_msgSend(menuItem, sel_registerName("setEnabled:"), (m->disabled ? false : true));
-          objc_msgSend(menuItem, sel_registerName("setState:"), (m->checked ? 1 : 0));
-          objc_msgSend(menuItem, sel_registerName("setRepresentedObject:"),
-            objc_msgSend((id)objc_getClass("NSValue"), sel_registerName("valueWithPointer:"), m));
+  for (; m != NULL && m->text != NULL; m++) {
+    if (strcmp(m->text, "-") == 0) {
+      id separatorItem = ((id (*)(id, SEL))objc_msgSend)(
+              (id)objc_getClass("NSMenuItem"),
+              sel_registerName("separatorItem"));
 
-          objc_msgSend(menu, sel_registerName("addItem:"), menuItem);
+      ((id (*)(id, SEL, id))objc_msgSend)(
+          menu,
+          sel_registerName("addItem:"),
+          separatorItem);
+    } else {
+      id menuItem = ((id (*)(id, SEL))objc_msgSend)(
+              (id)objc_getClass("NSMenuItem"),
+              sel_registerName("alloc"));
 
-          if (m->submenu != NULL) {
-            objc_msgSend(menu, sel_registerName("setSubmenu:forItem:"), _tray_menu(m->submenu), menuItem);
+      ((id (*)(id, SEL))objc_msgSend)(menuItem, sel_registerName("autorelease"));
+
+      ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(
+          menuItem,
+          sel_registerName("initWithTitle:action:keyEquivalent:"),
+          ((id (*)(id, SEL, const char *))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), m->text),
+          sel_registerName("menuCallback:"),
+          ((id (*)(id, SEL, const char *))objc_msgSend)((id)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), ""));
+
+      ((id (*)(id, SEL, bool))objc_msgSend)(menuItem, sel_registerName("setEnabled:"), (m->disabled ? false : true));
+      ((id (*)(id, SEL, bool))objc_msgSend)(menuItem, sel_registerName("setState:"), (m->checked ? 1 : 0));
+
+      ((id (*)(id, SEL, id))objc_msgSend)(
+          menuItem,
+          sel_registerName("setRepresentedObject:"),
+          ((id (*)(id, SEL, void*))objc_msgSend)((id)objc_getClass("NSValue"), sel_registerName("valueWithPointer:"), m));
+
+      ((id (*)(id, SEL, id))objc_msgSend)(menu, sel_registerName("addItem:"), menuItem);
+
+      if (m->submenu != NULL) {
+        ((id (*)(id, SEL, id, id))objc_msgSend)(
+            menu,
+            sel_registerName("setSubmenu:forItem:"),
+            _tray_menu(m->submenu),
+            menuItem);
       }
     }
   }
@@ -211,69 +233,102 @@ static id _tray_menu(struct tray_menu *m) {
 }
 
 static void menu_callback(id self, SEL cmd, id sender) {
-  struct tray_menu *m =
-      (struct tray_menu *)objc_msgSend(objc_msgSend(sender, sel_registerName("representedObject")),
-                  sel_registerName("pointerValue"));
+  struct tray_menu *m = ((struct tray_menu *(*)(id, SEL))objc_msgSend)(
+      ((id (*)(id, SEL))objc_msgSend)(sender, sel_registerName("representedObject")),
+      sel_registerName("pointerValue"));
 
-    if (m != NULL && m->cb != NULL) {
-      m->cb(m);
-    }
+  if (m != NULL && m->cb != NULL) {
+    m->cb(m);
+  }
 }
 
 static int tray_init(struct tray *tray) {
-    pool = objc_msgSend((id)objc_getClass("NSAutoreleasePool"),
-                          sel_registerName("new"));
+  pool = ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSAutoreleasePool"),
+      sel_registerName("new"));
 
-    objc_msgSend((id)objc_getClass("NSApplication"),
-                          sel_registerName("sharedApplication"));
+  ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSApplication"),
+      sel_registerName("sharedApplication"));
 
-    Class trayDelegateClass = objc_allocateClassPair(objc_getClass("NSObject"), "Tray", 0);
-    class_addProtocol(trayDelegateClass, objc_getProtocol("NSApplicationDelegate"));
-    class_addMethod(trayDelegateClass, sel_registerName("menuCallback:"), (IMP)menu_callback, "v@:@");
-    objc_registerClassPair(trayDelegateClass);
+  Class trayDelegateClass = objc_allocateClassPair(objc_getClass("NSObject"), "Tray", 0);
+  class_addProtocol(trayDelegateClass, objc_getProtocol("NSApplicationDelegate"));
+  class_addMethod(trayDelegateClass, sel_registerName("menuCallback:"), (IMP)menu_callback, "v@:@");
+  objc_registerClassPair(trayDelegateClass);
 
-    id trayDelegate = objc_msgSend((id)trayDelegateClass,
-                          sel_registerName("new"));
+  id trayDelegate = ((id (*)(id, SEL))objc_msgSend)(
+      (id)trayDelegateClass,
+      sel_registerName("new"));
 
-    app = objc_msgSend((id)objc_getClass("NSApplication"),
-                          sel_registerName("sharedApplication"));
+  app = ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSApplication"),
+      sel_registerName("sharedApplication"));
 
-    objc_msgSend(app, sel_registerName("setDelegate:"), trayDelegate);
+  ((id (*)(id, SEL, id))objc_msgSend)(
+      app,
+      sel_registerName("setDelegate:"),
+      trayDelegate);
 
-    statusBar = objc_msgSend((id)objc_getClass("NSStatusBar"),
-                          sel_registerName("systemStatusBar"));
+  statusBar = ((id (*)(id, SEL))objc_msgSend)(
+      (id)objc_getClass("NSStatusBar"),
+      sel_registerName("systemStatusBar"));
 
-    statusItem = objc_msgSend(statusBar, sel_registerName("statusItemWithLength:"), -1.0);
+  statusItem = ((id (*)(id, SEL, double))objc_msgSend)(
+      statusBar,
+      sel_registerName("statusItemWithLength:"),
+      -1.0);
 
-    objc_msgSend(statusItem, sel_registerName("retain"));
-    objc_msgSend(statusItem, sel_registerName("setHighlightMode:"), true);
-    statusBarButton = objc_msgSend(statusItem, sel_registerName("button"));
-    tray_update(tray);
-    objc_msgSend(app, sel_registerName("activateIgnoringOtherApps:"), true);
-    return 0;
+  ((id (*)(id, SEL))objc_msgSend)(statusItem, sel_registerName("retain"));
+  ((id (*)(id, SEL, bool))objc_msgSend)(statusItem, sel_registerName("setHighlightMode:"), true);
+
+  statusBarButton = ((id (*)(id, SEL))objc_msgSend)(statusItem, sel_registerName("button"));
+
+  tray_update(tray);
+
+  ((id (*)(id, SEL, bool))objc_msgSend)(
+      app,
+      sel_registerName("activateIgnoringOtherApps:"),
+      true);
+
+  return 0;
 }
 
 static int tray_loop(int blocking) {
-    id until = (blocking ?
-      objc_msgSend((id)objc_getClass("NSDate"), sel_registerName("distantFuture")) :
-      objc_msgSend((id)objc_getClass("NSDate"), sel_registerName("distantPast")));
+ id until = blocking
+     ? ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSDate"), sel_registerName("distantPast"))
+     : ((id (*)(id, SEL))objc_msgSend)((id)objc_getClass("NSDate"), sel_registerName("distantFuture"));
 
-    id event = objc_msgSend(app, sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"),
-                ULONG_MAX,
-                until,
-                objc_msgSend((id)objc_getClass("NSString"),
-                  sel_registerName("stringWithUTF8String:"),
-                  "kCFRunLoopDefaultMode"),
-                true);
-    if (event) {
-      objc_msgSend(app, sel_registerName("sendEvent:"), event);
-    }
-    return 0;
+ id event = ((id (*)(id, SEL, unsigned long, id, id, bool))objc_msgSend)(
+     app,
+     sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"),
+     ULONG_MAX,
+     until,
+     ((id (*)(id, SEL, const char*))objc_msgSend)(
+         (id)objc_getClass("NSString"),
+         sel_registerName("stringWithUTF8String:"),
+         "kCFRunLoopDefaultMode"),
+     true);
+
+ if (event) {
+   ((id (*)(id, SEL, id))objc_msgSend)(
+       app,
+       sel_registerName("sendEvent:"),
+       event);
+ }
+
+ return 0;
 }
 
 static void tray_update(struct tray *tray) {
-  objc_msgSend(statusBarButton, sel_registerName("setImage:"), tray->icon);
-  objc_msgSend(statusItem, sel_registerName("setMenu:"), _tray_menu(tray->menu));
+  ((id (*)(id, SEL, id))objc_msgSend)(
+      statusBarButton,
+      sel_registerName("setImage:"),
+      tray->icon);
+
+  ((id (*)(id, SEL, id))objc_msgSend)(
+      statusItem,
+      sel_registerName("setMenu:"),
+      _tray_menu(tray->menu));
 }
 
 static void tray_exit() {}

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -17,7 +17,7 @@ BZ_ISDARWIN = BZ_OS == 'darwin'
 BZ_ISWIN = BZ_OS == 'windows'
 BZ_ISVERBOSE = '--verbose' in sys.argv
 
-def get_arch(short_names = True, use_mac_rosetta = True):
+def get_arch(short_names = True, use_mac_rosetta = False):
     arch = platform.machine().lower()
 
     if BZ_ISDARWIN and arch == 'arm64' and use_mac_rosetta:
@@ -28,10 +28,10 @@ def get_arch(short_names = True, use_mac_rosetta = True):
 
     if short_names and (arch in ['aarch64']):
         arch = 'arm64'
-    
+
     if short_names and (arch in ['armv7l']):
         arch = 'armhf'
-    
+
     return arch
 
 def get_os_shortname():

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -215,11 +215,11 @@ def build_compiler_cmd():
         elif target_arch == 'arm64':
             cmd += '-arch arm64 '
         else:
-            print('ERR: Unsupported target architecture for macOS cross-compile: %s' % (target_arch))
+            print('ERR: Unsupported target architecture for macOS cross-compile: %s' % target_arch)
             sys.exit(1)
     else:
         if target_arch != arch:
-            print('ERR: Unable to cross-compile: target %s host %s' % (target_arch, arch))
+            print('ERR: Unable to cross-compile: target %s host %s' % target_arch, arch)
             sys.exit(1)
     return cmd
 


### PR DESCRIPTION
Based on #1010, but rebased to latest master.
Therefore it's reviewed best commit-by-commit.

**Note: I did not test if the artifacts are good because my own fork is missing the GitHub tokens.**

## Description

I've added cross-compilation to macOS, so we can compile for x64 and arm64 (Apple Silicon aka. M1 / M2) macs regardless of the CI platform.
This also makes CI more robust, as migration to arm based CPUs won't break the CI.

Additionally, we'll bundle the arm64 and x64 binary into a single universal binary (of larger size), so the user doesn't have to worry about picking the appropriate binary (which avoids Rosetta, if possible).

## Changes proposed

- Remove non-sensical `use_mac_rosetta` from build-script, because rosetta is an emulator at runtime, not a build flag
- Add arch argument to the macOS compiler line, so we select the target arch for cross-compilation (Documented here: https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Update-the-Architecture-List-of-Custom-Makefiles)
- Expose `target_arch` command line argument as a new flag. It takes the arch "short-name" (more of a portable and unique identifier really). Also migrated to Python `argparse` (Documented here: https://docs.python.org/3/library/argparse.html); the option uses the arch identification which is already used for `short_names`
- Add custom logic to bring the generic arch "short-name" into a format that's suitable for the compiler (which must be done per platform/compiler, so it's inherently tied to the python script). Because each compiler has their own preference for arch names (sometimes even depending on the context) it's not enough to have a generic substitution in the shell script.
- Trigger an error when trying to cross-compile on another OS. This should be possible, but it's untested, therefore blocked. We'll have to add more boilerplate to bring the arch names into whatever the compiler expects.
- Add GitHub Actions support to actually use the new command line argument, so we build 2 macOS binaries (x64 and arm64)
- Because GitHub Actions runs on macOS, we can build a universal binary using the `lipo` tool (Documented here: https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Update-the-Architecture-List-of-Custom-Makefiles)

## How to test it

- Run `./scripts/bz.py` on macOS, it should build for the host architecture
- Run `./scripts/bz.py --target_arch x64` on macOS, it should build for intel based mac
- Run `./scripts/bz.py --target_arch arm64` on macOS, it should build for apple based mac
- Run `./scripts/bz.py --target_arch x64` on a non x64 CPU and it should report an error (unless you are on macOS)
- Run `./scripts/bz.py --target_arch armhf` on a non armhf CPU and it should report an error (unless you are on macOS)
- Run `./scripts/bz.py --target_arch arm64` on a non arm64 CPU and it should report an error (unless you are on macOS)
- Push release, should have 3 macOS builds now (x64, arm64, universal)

## Next steps

Tests have not been touched, except forcing x64 build. I wasn't sure how the test script picks which neutralino binary to run (if any?), so it didn't seem useful to build both versions.
I also don't build the universal app during the test as it's not affected by code.

Some flags (for example `-host-arch` and `-arch`) in the Windows specific portion look very bad.
The flags added by the script and through the config JSON are also closely tied to the compiler in question.
Code should be refactored some more, so we can also build for Windows ARM from other archs.
However, I believe the build script needs major refactors in the future; I also wonder if it should be replaced with something like CMake which would solve many challenges while reducing code size (at expense of adding a very common dependency for C / C++ projects).

## Deploy notes

Should ensure that the 3 macOS builds are build properly (and are functional).
Hopefully no breakage in other portions