### PR TITLE
[#1053] Fix Windows Binary Corruption

### DIFF
--- a/api/filesystem/filesystem.cpp
+++ b/api/filesystem/filesystem.cpp
@@ -167,7 +167,7 @@ bool writeFile(const fs::FileWriterOptions &fileWriterOptions) {
     ios_base::openmode mode = ios_base::out | ios_base::binary;
     // For portability we use LF ('\n') always via ::binary
     if(fileWriterOptions.append) {
-        mode = ios_base::app | ios_base::binary;
+        mode |= ios_base::app;
     }
 
     ofstream writer(fileWriterOptions.filename, mode);

--- a/api/filesystem/filesystem.cpp
+++ b/api/filesystem/filesystem.cpp
@@ -167,7 +167,7 @@ bool writeFile(const fs::FileWriterOptions &fileWriterOptions) {
     ios_base::openmode mode = ios_base::out | ios_base::binary;
     // For portability we use LF ('\n') always via ::binary
     if(fileWriterOptions.append) {
-        mode = ios_base::app;
+        mode = ios_base::app | ios_base::binary;
     }
 
     ofstream writer(fileWriterOptions.filename, mode);


### PR DESCRIPTION
## Description
See #1053 for more details or sample test code. But this _should_ fix binary data being appended getting corrupted (due to Window EOL.) But this seems to fix my issues where downloaded zip files are corrupted on Windows. :)

## Changes proposed
- Handle  appending data as binary as well

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->

 - Run specs/tests
 - Can see the sample code in #1053

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
None.