### PR TITLE
Fix: Invalid file path in HTTP request returns global variables

### DIFF
--- a/server/router.cpp
+++ b/server/router.cpp
@@ -250,7 +250,7 @@ router::Response getAsset(string path, const string &prependData) {
     response.data = fileReaderResult.data;
     response.status = fileReaderResult.status != errors::NE_ST_OK ? websocketpp::http::status_code::not_found
                                 : websocketpp::http::status_code::ok;
-    if(prependData != "")
+    if(fileReaderResult.status == errors::NE_ST_OK && prependData != "")
         response.data = prependData + response.data;
 
     // If MIME-type is not defined in neuserver, application/octet-stream will be used by default.


### PR DESCRIPTION
## Description
Currently, a HTTP 404 status code is returned when the file path is invalid, however the message body contains all the global variables instead of a valid error message (Refer to issue #1058 ). With this PR, the router will now check if the file is read successfully before adding content to the response data.

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - Check for `fileReaderResult.status` before checking the contents of  `prependData` 

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

- A suitable message in the response body would be beneficial but I am not sure about the content.