### PR TITLE
Fix window title bar not respecting system theme (dark mode) on Windows 10 and 11

### DIFF
--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -64,7 +64,7 @@
             "/EHsc",
             "/Os",
             "/Fobin/",
-            "/link lib/webview/windows/WebView2Loader.dll.lib gdi32.lib version.lib Ole32.lib OleAut32.lib wbemuuid.lib ntdll.lib"
+            "/link lib/webview/windows/WebView2Loader.dll.lib gdi32.lib version.lib Ole32.lib OleAut32.lib wbemuuid.lib ntdll.lib dwmapi.lib"
         ]
     },
     "definitions": {

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -942,6 +942,8 @@ using browser_engine = cocoa_wkwebview_engine;
 #define TRAY_WINAPI 1
 #include "lib/tray/tray.h"
 
+#include "darkmode.h"
+
 namespace webview {
 
 using msg_cb_t = std::function<void(const std::string)>;
@@ -1296,6 +1298,9 @@ public:
     SetWindowLong(m_window, GWL_EXSTYLE, WS_EX_TOOLWINDOW);
     ShowWindow(m_window, SW_SHOW);
     SetFocus(m_window);
+
+    // set dark mode of title bar according to system theme
+    TrySetWindowTheme(m_window);
 
     auto cb =
         std::bind(&win32_edge_engine::on_message, this, std::placeholders::_1);

--- a/lib/webview/windows/darkmode.h
+++ b/lib/webview/windows/darkmode.h
@@ -1,0 +1,89 @@
+#include <dwmapi.h>  // DwmSetWindowAttribute()
+
+// Returns Windows' build number.
+// ntdll.dll -> RtlGetNtVersionNumbers
+DWORD GetBuildNumber() {
+    HMODULE hNtdll = ::GetModuleHandleW(L"ntdll.dll");
+    if (hNtdll) {
+        typedef void(__stdcall*fnRtlGetNtVersionNumbers)(DWORD*, DWORD*, DWORD*);
+        fnRtlGetNtVersionNumbers proc = (fnRtlGetNtVersionNumbers)GetProcAddress(hNtdll, "RtlGetNtVersionNumbers");  
+        if (proc != nullptr) {
+            DWORD dwMajor, dwMinor, dwBuildNumber;
+            proc(&dwMajor, &dwMinor, &dwBuildNumber);
+            dwBuildNumber &= ~0xF0000000;
+            return dwBuildNumber;
+        }
+    }
+    return 0;
+}
+
+// Build numbers 22000 and above are Windows 11.
+bool IsWindows10() {
+    return GetBuildNumber() < 22000;
+}
+
+// Returns whether High Contrast theme is enabled.
+// user32.dll -> SystemParametersInfoW
+bool IsHighContrast() {
+    HMODULE hUser32 = ::GetModuleHandleA("user32.dll");
+    if (hUser32) {
+        typedef BOOL (WINAPI * fnSystemParametersInfo)(UINT, UINT, PVOID, UINT);
+        fnSystemParametersInfo proc = (fnSystemParametersInfo)GetProcAddress(hUser32, "SystemParametersInfoW");
+        if (proc) {
+            HIGHCONTRASTW highContrast = { sizeof(highContrast) };
+            if (proc(SPI_GETHIGHCONTRAST, sizeof(highContrast), &highContrast, FALSE))
+                return highContrast.dwFlags & HCF_HIGHCONTRASTON;
+        }
+    }
+	return false;
+}
+
+// Returns whether system-wide dark mode is enabled.
+// uxtheme.dll -> ShouldSystemUseDarkMode
+bool IsDarkModePreferred() {
+    HMODULE hUxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (hUxtheme) {
+        // typedef BOOLEAN (WINAPI * fnShouldAppsUseDarkMode)(); // ordinal 132
+        typedef BOOLEAN (WINAPI * fnShouldSystemUseDarkMode)(); // ordinal 138
+        // fnShouldAppsUseDarkMode proc = (fnShouldAppsUseDarkMode)(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(132)));
+        fnShouldSystemUseDarkMode proc = (fnShouldSystemUseDarkMode)(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(138)));
+        if (proc != nullptr) {
+            return proc();
+        }
+    }
+    return false;
+}
+
+// Sets flags to enable dark title bar in Windows 10 and 11.
+// dwmapi.lib -> DwmSetWindowAttribute
+HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
+    const BOOL isDarkMode = dark;
+    
+    // set DWMWA_USE_IMMERSIVE_DARK_MODE
+    // This flag works since Win10 20H1 but is not documented until Windows 11
+    HRESULT result = DwmSetWindowAttribute(hWnd, 20, &isDarkMode, sizeof(isDarkMode));
+
+    if (FAILED(result)) {
+        // this would be the call before Windows build 18362
+        result = DwmSetWindowAttribute(hWnd, 19, &isDarkMode, sizeof(isDarkMode));
+    }
+
+    if (FAILED(result))
+        return result;
+
+    // Toggle the nonclient area active state to force a redraw (Win10 workaround)
+    if (IsWindows10()) {
+        HWND activeWindow = GetActiveWindow();
+        SendMessage(hWnd, WM_NCACTIVATE, hWnd != activeWindow, 0);
+        SendMessage(hWnd, WM_NCACTIVATE, hWnd == activeWindow, 0);
+    }
+
+    return S_OK;
+}
+
+// Sets dark mode of title bar according to system theme.
+HRESULT TrySetWindowTheme(HWND hWnd) {
+    if (IsDarkModePreferred() && !IsHighContrast())
+        return TrySetWindowTheme(hWnd, true);
+    return S_OK;
+}


### PR DESCRIPTION
## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->

On Windows 10 and 11, if you run `neu run` or create an app using `neu build` and run that, it will always show a white title bar, regardless of whether system-wide dark mode is enabled.

This pull request makes the window title bar respect the system theme under Windows 10 and 11. See screenshot:

![neutralino-win_x64](https://user-images.githubusercontent.com/47528453/223761240-45210497-de2d-41fe-9b35-cc3102a9f62d.png)

This should also close the issue https://github.com/neutralinojs/neutralinojs/issues/916

I also made sure to compile and run the code on Ubuntu 22.10, just to make sure that the changes don't affect the other platforms.

<details>
<summary>Ubuntu screenshot</summary>

![neutralino-linux_x64](https://user-images.githubusercontent.com/47528453/223767509-b6f6b058-0c56-4a77-9d6b-6acf1efe73b7.png)

</details>

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - Added `lib/webview/windows/darkmode.h` with functions that call Windows APIs to change title bar color
 - Linked dependency `dwmapi.lib` inside `buildzri.config.json`

## Some more notes

I had to dig quite a while to find a solution to this. Electron has already implemented this and so did mintty. So, I took some "inspiration" from their code...

Here are all my sources for those interested:
<details>
<summary>Sources</summary>

- Electron on GitHub
  - https://github.com/electron/electron/blob/77bd80dfb21e0d4419eff093e5232dd8fb05432f/shell/browser/win/dark_mode.cc
- mintty on GitHub
  - https://github.com/mintty/mintty/issues/983
  - https://github.com/mintty/mintty/commit/3aaedf62b277c70a4389efe69107c3c1c9045575
  - https://github.com/mintty/mintty/blob/c553518ad6454e7ee4894b70aefe1ab5b878db56/src/winmain.c#L1951
- ysc3839's win32-darkmode on GitHub
  - https://github.com/ysc3839/win32-darkmode/blob/master/win32-darkmode/DarkMode.h
- Other online sources:
  - https://learn.microsoft.com/en-us/answers/questions/672988/(c-)-detect-windows-build
  - https://github.com/3gstudent/Homework-of-C-Language/blob/master/sekurlsa-wdigest.cpp#L594

</details>

I should say that I'm not a C++ / WINAPI programmer. If there's anything wrong with the code style or the code itself, please tell me.