### PR TITLE
Setting the window position from app config and CLI

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -98,7 +98,7 @@ void __undoFakeHidden() {
 	ShowWindow(windowHandle, SW_HIDE);
 	SetWindowLong(windowHandle, GWL_EXSTYLE, nativeWindow->m_originalStyleEx);
 	SetWindowPos(windowHandle, nullptr,
-        10, 10, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
+        windowProps.x, windowProps.y, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
 	ShowWindow(windowHandle, SW_SHOW);
 }
 #endif
@@ -400,7 +400,9 @@ void __createWindow() {
     windowHandle = (HWND) nativeWindow->window();
     #endif
 
+    #if !defined(_WIN32)
     window::move(windowProps.x, windowProps.y);
+    #endif
 
     if(windowProps.maximize)
         window::maximize();

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -87,7 +87,7 @@ void windowStateChange(int state) {
 bool __isFakeHidden() {
 	// Checks whether the window is on the screen viewport
 	RECT winPos;
-	
+
 	if(GetWindowRect( windowHandle, &winPos)) {
 		return winPos.left > 9999;
 	}
@@ -97,7 +97,7 @@ bool __isFakeHidden() {
 void __undoFakeHidden() {
 	ShowWindow(windowHandle, SW_HIDE);
 	SetWindowLong(windowHandle, GWL_EXSTYLE, nativeWindow->m_originalStyleEx);
-	SetWindowPos(windowHandle, nullptr, 
+	SetWindowPos(windowHandle, nullptr,
         10, 10, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
 	ShowWindow(windowHandle, SW_SHOW);
 }
@@ -166,7 +166,7 @@ bool isFakeHidden() {
 	//ensureOnScreen
 	#if defined(_WIN32)
 	RECT rect = { NULL };
-	
+
 	if(GetWindowRect( windowHandle, &rect)) {
 		return rect.left > 9999;
 	}
@@ -324,6 +324,23 @@ void setIcon(const string &iconFile) {
     #endif
 }
 
+void move(int x, int y) {
+    #if defined(__linux__) || defined(__FreeBSD__)
+    gtk_window_move(GTK_WINDOW(windowHandle), x, y);
+    #elif defined(__APPLE__)
+    auto displayId = CGMainDisplayID();
+    int height = CGDisplayPixelsHigh(displayId);
+    ((void (*)(id, SEL, CGPoint))objc_msgSend)(
+        (id) windowHandle, "setFrameTopLeftPoint:"_sel,
+        CGPointMake(x, height - y));
+    #elif defined(_WIN32)
+    RECT winPos;
+    GetWindowRect(windowHandle, &winPos);
+    MoveWindow(windowHandle, x, y, winPos.right - winPos.left,
+                winPos.bottom - winPos.top, true);
+    #endif
+}
+
 void setAlwaysOnTop(bool onTop) {
     #if defined(__linux__) || defined(__FreeBSD__)
     gtk_window_set_keep_above(GTK_WINDOW(windowHandle), onTop);
@@ -382,6 +399,8 @@ void __createWindow() {
     #elif defined(_WIN32)
     windowHandle = (HWND) nativeWindow->window();
     #endif
+
+    window::move(windowProps.x, windowProps.y);
 
     if(windowProps.maximize)
         window::maximize();
@@ -604,20 +623,7 @@ json move(const json &input) {
     }
     int x = input["x"].get<int>();
     int y = input["y"].get<int>();
-    #if defined(__linux__) || defined(__FreeBSD__)
-    gtk_window_move(GTK_WINDOW(windowHandle), x, y);
-    #elif defined(__APPLE__)
-    auto displayId = CGMainDisplayID();
-    int height = CGDisplayPixelsHigh(displayId);
-    ((void (*)(id, SEL, CGPoint))objc_msgSend)(
-        (id) windowHandle, "setFrameTopLeftPoint:"_sel,
-        CGPointMake(x, height - y));
-    #elif defined(_WIN32)
-    RECT winPos;
-    GetWindowRect(windowHandle, &winPos);
-    MoveWindow(windowHandle, x, y, winPos.right - winPos.left,
-                winPos.bottom - winPos.top, true);
-    #endif
+    window::move(x, y);
     output["success"] = true;
     return output;
 }
@@ -698,6 +704,12 @@ json init(const json &input) {
     json output;
 
     windowProps.sizeOptions = __jsonToSizeOptions(input, true);
+
+    if(helpers::hasField(input, "x"))
+        windowProps.x = input["x"].get<int>();
+
+    if(helpers::hasField(input, "y"))
+        windowProps.y = input["y"].get<int>();
 
     if(helpers::hasField(input, "fullScreen"))
         windowProps.fullScreen = input["fullScreen"].get<bool>();

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -54,6 +54,8 @@ struct WindowOptions {
     string title = "Neutralinojs window";
     string url = "https://neutralino.js.org";
     string icon = "";
+    int x = 0;
+    int y = 0;
 };
 
 namespace handlers {
@@ -76,6 +78,7 @@ void setFullScreen();
 void exitFullScreen();
 bool isFullScreen();
 void setIcon(const string &icon);
+void move(int x, int y);
 void setAlwaysOnTop(bool onTop);
 void setBorderless();
 

--- a/bin/neutralino.config.json
+++ b/bin/neutralino.config.json
@@ -29,6 +29,8 @@
     "modes": {
         "window": {
             "title": "Neutralinojs app",
+            "x": 200,
+            "y": 400,
             "width": 800,
             "height": 500,
             "minWidth": 400,

--- a/settings.cpp
+++ b/settings.cpp
@@ -190,6 +190,8 @@ void applyConfigOverride(const settings::CliArg &arg) {
         {"--window-min-height", {"/modes/window/minHeight", "int"}},
         {"--window-max-width", {"/modes/window/maxWidth", "int"}},
         {"--window-max-height", {"/modes/window/maxHeight", "int"}},
+        {"--window-x", {"/modes/window/x", "int"}},
+        {"--window-y", {"/modes/window/y", "int"}},
         {"--window-full-screen", {"/modes/window/fullScreen", "bool"}},
         {"--window-always-on-top", {"/modes/window/alwaysOnTop", "bool"}},
         {"--window-enable-inspector", {"/modes/window/enableInspector", "bool"}},


### PR DESCRIPTION
- Adds `modes.window.x` and `modes.window.y` integer props to config
- Adds config overrides: `--window-x=<int>` and `--window-y=<int>`