### PR TITLE
Fix Unicode in the Windows version of Neutralino.js

### DIFF
--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -43,7 +43,8 @@
         "windows": [
             "lib/tinyprocess/process_win.cpp",
             "lib/clip/clip_win.cpp",
-            "lib/efsw/src/efsw/platform/win/*.cpp"
+            "lib/efsw/src/efsw/platform/win/*.cpp",
+            "utils/win/str_conv.cpp"
         ]
     },
     "options": {

--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -89,7 +89,9 @@
         "windows": [
             "_WEBSOCKETPP_CPP11_STL_",
             "_HAS_STD_BYTE=0",
-            "TRAY_WINAPI=1"
+            "TRAY_WINAPI=1",
+            "UNICODE",
+            "_UNICODE"
         ]
     }
 }

--- a/lib/tray/tray.h
+++ b/lib/tray/tray.h
@@ -350,7 +350,7 @@ static HMENU _tray_menu(struct tray_menu *m, UINT *id) {
   HMENU hmenu = CreatePopupMenu();
   for (; m != NULL && m->text != NULL; m++, (*id)++) {
     if (strcmp(m->text, "-") == 0) {
-      InsertMenu(hmenu, *id, MF_SEPARATOR, TRUE, "");
+      InsertMenu(hmenu, *id, MF_SEPARATOR, TRUE, L"");
     } else {
       MENUITEMINFO item;
       memset(&item, 0, sizeof(item));
@@ -369,7 +369,7 @@ static HMENU _tray_menu(struct tray_menu *m, UINT *id) {
         item.fState |= MFS_CHECKED;
       }
       item.wID = *id;
-      item.dwTypeData = (LPSTR)m->text;
+      item.dwTypeData = (LPWSTR)m->text;
       item.dwItemData = (ULONG_PTR)m;
 
       InsertMenuItem(hmenu, *id, TRUE, &item);
@@ -380,7 +380,7 @@ static HMENU _tray_menu(struct tray_menu *m, UINT *id) {
 
 static int tray_init(struct tray *tray) {
 
-  hwnd = FindWindow("Neutralinojs_webview", NULL);
+  hwnd = FindWindow(L"Neutralinojs_webview", NULL);
   if (hwnd == NULL) {
     return -1;
   }

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -942,6 +942,7 @@ using browser_engine = cocoa_wkwebview_engine;
 #define TRAY_WINAPI 1
 #include "lib/tray/tray.h"
 
+#include "utils/win/str_conv.cpp"
 #include "darkmode.h"
 
 namespace webview {
@@ -1200,7 +1201,7 @@ public:
       ZeroMemory(&wc, sizeof(WNDCLASSEX));
       wc.cbSize = sizeof(WNDCLASSEX);
       wc.hInstance = hInstance;
-      wc.lpszClassName = "Neutralinojs_webview";
+      wc.lpszClassName = L"Neutralinojs_webview";
       wc.hIcon = icon;
       wc.hIconSm = icon;
       wc.lpfnWndProc =
@@ -1278,7 +1279,7 @@ public:
             return 0;
           });
       RegisterClassEx(&wc);
-      m_window = CreateWindow("Neutralinojs_webview", "", WS_OVERLAPPEDWINDOW, 99999999,
+      m_window = CreateWindow(L"Neutralinojs_webview", L"", WS_OVERLAPPEDWINDOW, 99999999,
                               CW_USEDEFAULT, 640, 480, nullptr, nullptr,
                               GetModuleHandle(nullptr), nullptr);
       SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
@@ -1344,14 +1345,14 @@ public:
   }
 
   void set_title(const std::string title) {
-    SetWindowText(m_window, title.c_str());
+    SetWindowText(m_window, str2wstr(title).c_str());
   }
 
   std::string get_title() {
     int len = GetWindowTextLength(hwnd);
     std::string title;
     title.reserve(len + 1);
-    GetWindowText(hwnd, const_cast<char*>(title.c_str()), len);
+    GetWindowText(hwnd, const_cast<LPWSTR>(str2wstr(title).c_str()), len);
     return title;
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #if defined(_WIN32)
 #include <winsock2.h>
 #include <websocketpp/error.hpp>
+#include "utils/win/str_conv.cpp"
 #endif
 
 #include "lib/json/json.hpp"
@@ -166,20 +167,22 @@ void __initExtra() {
 
 #if defined(_WIN32)
 #define ARG_C __argc
-#define ARG_V __argv
-int APIENTRY WinMain(HINSTANCE hInstance,
-                     HINSTANCE hPrevInstance,
-                     LPTSTR    lpCmdLine,
-                     int       nCmdShow)
+#define ARG_V __wargv
+#define CONVSTR(S) wcstr2str(S)
+int APIENTRY wWinMain(HINSTANCE hInstance,
+                      HINSTANCE hPrevInstance,
+                      LPTSTR    lpCmdLine,
+                      int       nCmdShow)
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #define ARG_C argc
 #define ARG_V argv
+#define CONVSTR(S) S
 int main(int argc, char ** argv)
 #endif
                                  {
     json args;
     for (int i = 0; i < ARG_C; i++) {
-        args.push_back(ARG_V[i]);
+        args.push_back(CONVSTR(ARG_V[i]));
     }
     __initFramework(args);
     __startServerAsync();

--- a/resources.cpp
+++ b/resources.cpp
@@ -14,6 +14,16 @@
 #include "api/debug/debug.h"
 #include "api/filesystem/filesystem.h"
 
+#if defined(_WIN32)
+// ifstream and ofstream do not support UTF-8 file paths on Windows.
+// However there is a non-standard extension which allows the use of wide strings.
+// So, before we pass the path string to the constructor, we have to convert it to a UTF-16 std::wstring.
+#include "utils/win/str_conv.cpp"
+#define CONVSTR(S) str2wstr(S)
+#else
+#define CONVSTR(S) S
+#endif
+
 #define NEU_APP_RES_FILE "/resources.neu"
 
 using namespace std;
@@ -44,7 +54,7 @@ ifstream __openResourceFile() {
     ifstream asarArchive;
     string resFileName = NEU_APP_RES_FILE;
     resFileName = settings::joinAppPath(resFileName);
-    asarArchive.open(resFileName, ios::binary);
+    asarArchive.open(CONVSTR(resFileName), ios::binary);
     if(!asarArchive) {
         debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_RS_TREEGER, resFileName));
     }

--- a/utils/win/str_conv.cpp
+++ b/utils/win/str_conv.cpp
@@ -1,0 +1,33 @@
+// Windows-only
+#if defined(_WIN32)
+
+#include <string>    // std::string, std::wstring
+#include <windows.h> // LPSTR, LPWSTR, CP_UTF8, MultiByteToWideChar, WideCharToMultiByte
+
+static inline std::wstring str2wstr(std::string const &str)
+{
+    int len = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), (int)str.size(), nullptr, 0);
+    std::wstring ret(len, '\0');
+    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), (int)str.size(), (LPWSTR)ret.data(), (int)ret.size());
+    return ret;
+}
+
+static inline std::string wstr2str(std::wstring const &str)
+{
+    int len = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.size(), nullptr, 0, nullptr, nullptr);
+    std::string ret(len, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.size(), (LPSTR)ret.data(), (int)ret.size(), nullptr, nullptr);
+    return ret;
+}
+
+static inline std::string wcstr2str(const wchar_t* wstr)
+{
+    int count = WideCharToMultiByte(CP_UTF8, 0, wstr, wcslen(wstr), NULL, 0, NULL, NULL);
+    std::string str(count, 0);
+    WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &str[0], count, NULL, NULL);
+    return str;
+}
+
+#else
+#error Do not include str_conv.cpp under Posix.
+#endif


### PR DESCRIPTION
## Description

Under Windows, Neutralino doesn't support Unicode, see the linked issues below.  
This pull request should hopefully fix this, by using the Unicode WinApi.

### Related issues and posts
- [GSOC2023 - Support Unicode characters in Neutralinojs Windows version](https://github.com/neutralinojs/gsoc2023#2-support-unicode-characters-in-neutralinojs-windows-version)
- [Issue #613 - UTF-8 not supported in Native API](https://github.com/neutralinojs/neutralinojs/issues/613)
- [Issue #782 - filesystem.readDirectory fails when results would return filenames containing umlauts](https://github.com/neutralinojs/neutralinojs/issues/782)
- [Issue #808 - starter template crashes on windows 10 - error code 3221225477](https://github.com/neutralinojs/neutralinojs/issues/808)
- [Issue #960 - No Unicode support in Windows](https://github.com/neutralinojs/neutralinojs/issues/960)

### Broken functions / issues
- Native API fails when working with Unicode
  - `Neutralino.filesystem.readDirectory`
  - `Neutralino.filesystem.createDirectory`
  - `Neutralino.os.execCommand`
  - `Neutralino.os.spawnProcess`
  - `Neutralino.os.updateSpawnedProcess`
  - `Neutralino.window.setTitle`
  - (possibly more)
- Neutralino crashes on start if it's in a path with e.g. "Umlaut" characters (`ä`, `ö`, `ü`, or other non-ANSI characters)
- Neutralino does not display Unicode characters in the window title correctly (non-ANSI characters are garbled or question marks, see screenshots)

### Screenshots
#### Before
![neutralino-win_x64 bak_CwgBMmDGpL](https://user-images.githubusercontent.com/47528453/236188788-de26bfcc-e464-457d-b1a9-65a71311451e.png)

#### After
![neutralino-win_x64_zKsWTHBbQO](https://user-images.githubusercontent.com/47528453/236188769-3cf88b27-371e-475b-9fd2-d3085d1445b6.png)

## Changes proposed
- Define `UNICODE` and `_UNICODE` at compile time to force the use of wide string versions of the WinApi.
- Use `wWinMain` and `__wargv` instead of `WinMain` and `__argv`.
- Replace -`A` WinApi calls with generic calls: e.g. `PathRemoveFileSpecA` → `PathRemoveFileSpec` (will expand to `PathRemoveFileSpecW`)
- Convert between `std::string` and `std::wstring`, as well as `char*` and `wchar_t*` where needed.
- Use `L""` strings where needed. (or using `_T()` macro from `tchar.h`)
- Convert paths from `std::string` (UTF-8 encoding) to `std::wstring` (UTF-16 encoding) when opening an `ifstream` or an `ofstream`. (under Windows, `ifstream` and `ofstream` only support ANSI or UTF-16)

### Sources
<details>
<summary>Click to see sources</summary>

- [WinAPI: A and W functions](https://renenyffenegger.ch/notes/Windows/development/WinAPI/A-and-W-functions)
- [TEXT vs. _TEXT vs. _T, and UNICODE vs. _UNICODE](https://devblogs.microsoft.com/oldnewthing/20040212-00/?p=40643)
- [Read and write binary files with UTF-8 file names on windows](https://stackoverflow.com/a/67577383)
- [Conversion methods](https://github.com/samhocevar/portable-file-dialogs/blob/67e7b0945aac80efa2ec5c72de98b47f7552735c/portable-file-dialogs.h#L420)
- [FAQ - JSON for Modern C++ - Parse errors reading non-ASCII characters](https://json.nlohmann.me/home/faq/#parse-errors-reading-non-ascii-characters)
- [UTF-8 Everywhere - 10. How to do text on Windows](https://utf8everywhere.org/#windows)
- [MSDN - Generic-Text Mappings in tchar.h](https://learn.microsoft.com/en-us/cpp/text/generic-text-mappings-in-tchar-h?view=msvc-170)

</details>

## Notes

I tried my best to test this PR (including running and passing the test suite), but I'm not sure, since it changes a lot.
It compiles and runs on Windows and GNU/Linux, but I couldn't test macOS, since I don't own a mac.  
Also, I added a `utils` folder, since I didn't know where to best put `str_conv.cpp`.