### PR TITLE
Fix non-changing of tray icon on linux

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -601,7 +601,7 @@ json setTray(const json &input) {
             static bool useOtherTempFile = true;
             useOtherTempFile = !useOtherTempFile;
             string tempIconPath = settings::joinAppPath(
-                    useOtherTempFile ?  "/.tmp/tray_icon_linux.png" : "/.tmp/tray_icon_linux2.png"
+                    useOtherTempFile ?  "/.tmp/tray_icon_linux_01.png" : "/.tmp/tray_icon_linux_02.png"
             );
 
             string tempDirPath = settings::joinAppPath("/.tmp");

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -595,9 +595,17 @@ json setTray(const json &input) {
             fullIconPath = fs::getFullPathFromRelative(settings::joinAppPath("")) + iconPath;
         }
         else {
+            // Use alternating tempIconPath since tray_update()
+            // doesn't update the icon if the path is the same as the previous one,
+            // regardless whether the file contents changed or not.
+            static bool useOtherTempFile = true;
+            useOtherTempFile = !useOtherTempFile;
+            string tempIconPath = settings::joinAppPath(
+                    useOtherTempFile ?  "/.tmp/tray_icon_linux.png" : "/.tmp/tray_icon_linux2.png"
+            );
+
             string tempDirPath = settings::joinAppPath("/.tmp");
             fs::createDirectory(tempDirPath);
-            string tempIconPath = settings::joinAppPath("/.tmp/tray_icon_linux.png");
             resources::extractFile(iconPath, tempIconPath);
             fullIconPath = fs::getFullPathFromRelative(tempIconPath);
         }


### PR DESCRIPTION
## Description
Fixes a bug on linux  #1115  where the tray icon doesn't after initial call.

## Changes proposed
Use alternating temporary filenames so tray_update() would work as expected.

