### PR TITLE
Improved Win32 window style handling with ~WS_EX_APPWINDOW

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -184,6 +184,7 @@ void maximize() {
     gtk_window_maximize(GTK_WINDOW(windowHandle));
     #elif defined(_WIN32)
     ShowWindow(windowHandle, SW_MAXIMIZE);
+    SetForegroundWindow(windowHandle);
     #elif defined(__APPLE__)
     ((void (*)(id, SEL, id))objc_msgSend)((id) windowHandle,
         "zoom:"_sel, NULL);
@@ -197,6 +198,7 @@ void unmaximize() {
     gtk_window_unmaximize(GTK_WINDOW(windowHandle));
     #elif defined(_WIN32)
     ShowWindow(windowHandle, SW_RESTORE);
+    SetForegroundWindow(windowHandle);
     #elif defined(__APPLE__)
     ((void (*)(id, SEL, id))objc_msgSend)((id) windowHandle,
         "zoom:"_sel, NULL);
@@ -246,6 +248,7 @@ void show() {
                 "setIsVisible:"_sel, true);
     #elif defined(_WIN32)
     ShowWindow(windowHandle, SW_SHOW);
+    SetForegroundWindow(windowHandle);
     if (__isFakeHidden())
 		__undoFakeHidden();
     #endif

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1289,17 +1289,15 @@ public:
     }
 
     setDpi();
+
+    // stop the taskbar icon from showing by removing WS_EX_APPWINDOW.
+    SetWindowLong(m_window, GWL_EXSTYLE, GetWindowLong(m_window, GWL_EXSTYLE) & ~WS_EX_APPWINDOW);
     ShowWindow(m_window, SW_SHOW);
     UpdateWindow(m_window);
+    SetForegroundWindow(m_window);
 
     // store the original initial window style
     m_originalStyleEx = GetWindowLong(m_window, GWL_EXSTYLE);
-
-    // stop the taskbar icon from showing by changing windowstyle to toolwindow.
-    ShowWindow(m_window, SW_HIDE);
-    SetWindowLong(m_window, GWL_EXSTYLE, WS_EX_TOOLWINDOW);
-    ShowWindow(m_window, SW_SHOW);
-    SetFocus(m_window);
 
     // set dark mode of title bar according to system theme
     TrySetWindowTheme(m_window);


### PR DESCRIPTION
## Description
`WS_EX_TOOLWINDOW` is not the best way to remove taskbar icon for an application, because it has the counter-effect to change the visual style of the affected window.

## How to reproduce
My application window starts hidden (thanks to `window-hidden: true` in `neutralino.config.json`.
Just after start it reads last window position/size, then calls `Neutralino.window.show()` to show the window.
Doing this, the native window is missing the minimize/maximize buttons and it appears as a tool-window (with only the small close button).

## Changes proposed
Best way to remove icon is to create a window **without** the `WS_EX_APPWINDOW` style, and then ensure it's focused each time it's shown/hidden/maximized/restored.