### PR TITLE
Support extending the default user agent string

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -525,6 +525,9 @@ void __createWindow() {
 
     nativeWindow = new webview::webview(windowProps.enableInspector, nullptr);
     nativeWindow->set_title(windowProps.title);
+    if(windowProps.extendUserAgentWith != "") {
+        nativeWindow->extend_user_agent(windowProps.extendUserAgentWith);
+    }
     nativeWindow->set_size(windowProps.sizeOptions.width,
                     windowProps.sizeOptions.height,
                     windowProps.sizeOptions.minWidth, windowProps.sizeOptions.minHeight,
@@ -823,6 +826,9 @@ json init(const json &input) {
 
     if(helpers::hasField(input, "icon"))
         windowProps.icon = input["icon"].get<string>();
+
+    if(helpers::hasField(input, "extendUserAgentWith"))
+        windowProps.extendUserAgentWith = input["extendUserAgentWith"].get<string>();
 
     if(helpers::hasField(input, "enableInspector"))
         windowProps.enableInspector = input["enableInspector"].get<bool>();

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -59,6 +59,7 @@ struct WindowOptions {
     string title = "Neutralinojs window";
     string url = "https://neutralino.js.org";
     string icon = "";
+    string extendUserAgentWith = "";
     int x = 0;
     int y = 0;
 };

--- a/bin/neutralino.config.json
+++ b/bin/neutralino.config.json
@@ -46,7 +46,8 @@
             "resizable": true,
             "exitProcessOnClose": false,
             "useSavedState": true,
-            "port": 0
+            "port": 0,
+            "extendUserAgentWith": "NeutralinojsSampleApp"
         },
         "browser": {
             "globalVariables": {

--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -1,7 +1,7 @@
 {
     "std": "c++17",
     "name": "Neutralinojs",
-    "version": "4.14.1",
+    "version": "4.15.0",
     "output": "./bin/neutralino-${BZ_OS}_${BZ_TARGET_ARCH}",
     "include": {
         "*": [

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -562,6 +562,13 @@ public:
     gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());
   }
 
+  void extend_user_agent(const std::string customAgent) {
+    WebKitSettings *settings =
+      webkit_web_view_get_settings(WEBKIT_WEB_VIEW(m_webview));
+      std::string ua = std::string(webkit_settings_get_user_agent(settings)) + " " + customAgent;
+      webkit_settings_set_user_agent(settings, ua.c_str());
+  }
+
   std::string get_title() {
     std::string title(gtk_window_get_title(GTK_WINDOW(m_window)));
     return title;
@@ -1432,7 +1439,7 @@ private:
     MultiByteToWideChar(CP_UTF8, 0, str.c_str(), (int)str.size(), (LPWSTR)ret.data(), (int)ret.size());
     return ret;
   }
-  
+
   std::string wstr2str(std::wstring const &str)
   {
     int len = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.size(), nullptr, 0, nullptr, nullptr);

--- a/settings.cpp
+++ b/settings.cpp
@@ -224,6 +224,7 @@ void applyConfigOverride(const settings::CliArg &arg) {
         {"--window-exit-process-on-close", {"/modes/window/exitProcessOnClose", "bool"}},
         {"--window-use-saved-state", {"/modes/window/useSavedState", "bool"}},
         {"--window-icon", {"/modes/window/icon", "string"}},
+        {"--window-extend-user-agent-with", {"/modes/window/extendUserAgentWith", "string"}},
         // Chrome mode
         {"--chrome-width", {"/modes/chrome/width", "int"}},
         {"--chrome-height", {"/modes/chrome/height", "int"}},

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+const runner = require('./runner');
+
+describe('config.spec: App configuration tests', () => {
+
+    it('extends the default user agent', async () => {
+        runner.run(`
+            await __close(navigator.userAgent);
+        `, {args: '--window-extend-user-agent-with="TestUserAgentValue"'});
+
+        assert.ok(runner.getOutput().includes('TestUserAgentValue'));
+    });
+
+});


### PR DESCRIPTION
Fixes #396 

- Extends user agent via the `window.extendUserAgentWith` configuration property
- Available as a command-line option: `--window-extend-user-agent-with=<string>`