### PR TITLE
test runner uses process.arch on mac

### DIFF
--- a/spec/runner.js
+++ b/spec/runner.js
@@ -85,7 +85,7 @@ function makeCommand(optArgs = '') {
         command += 'linux_' + process.arch
     }
     else if(process.platform == 'darwin') {
-        command += 'mac_x64'
+        command += 'mac_' + process.arch
     }
     else if(process.platform == 'win32') {
         command += 'win_x64.exe'


### PR DESCRIPTION
## Description
test runner uses process.arch on mac, like on linux

## How to test it
Run specs/tests on an arm based mac
