### PR TITLE
Functionality to overwrite files with `filesystem.copy()`

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -624,7 +624,9 @@ json copy(const json &input) {
     string destination = input["destination"].get<string>();
 
     error_code ec;
-    filesystem::copy(source, destination, filesystem::copy_options::recursive, ec);
+    const auto copyOptions = filesystem::copy_options::recursive
+                           | filesystem::copy_options::overwrite_existing;
+    filesystem::copy(source, destination, copyOptions, ec);
 
     if(!ec) {
         output["success"] = true;

--- a/bin/resources/js/main_spec.js
+++ b/bin/resources/js/main_spec.js
@@ -1,0 +1,34 @@
+
+
+
+Neutralino.init();
+
+Neutralino.events.on("ready", async () => {
+    await __init();
+    
+                await Neutralino.filesystem.createDirectory(NL_PATH + '/.tmp/abc');
+                await __close('done');
+            
+});
+
+async function __close(data = "", exitCode = 0) {
+    if(data) {
+        await Neutralino.filesystem.writeFile(NL_PATH + "/.tmp/output.txt", data);
+    }
+    setTimeout(async () => {
+        await Neutralino.app.exit(exitCode); // normal exit
+    }, 2000);
+}
+
+async function __init() {
+    try {
+        await Neutralino.filesystem.createDirectory(NL_PATH + "/.tmp");
+    }
+    catch(err) {
+        // ignore
+    }
+    setTimeout(async () => {
+        await Neutralino.filesystem.writeFile(NL_PATH + "/.tmp/output.txt", 'NL_SP_MAXTIMT');
+        await Neutralino.app.exit(1); // max timeout force exit
+    }, 20000);
+}

--- a/spec/filesystem.spec.js
+++ b/spec/filesystem.spec.js
@@ -409,6 +409,15 @@ describe('filesystem.spec: filesystem namespace tests', () => {
             `);
             assert.equal(runner.getOutput(), 'done');
         });
+        it('works when the destination file already exists', async () => {
+            runner.run(`
+                await Neutralino.filesystem.writeFile(NL_PATH + '/.tmp/test.txt', 'Hello');
+                await Neutralino.filesystem.writeFile(NL_PATH + '/.tmp/test_new.txt', 'Hello');
+                await Neutralino.filesystem.copy(NL_PATH + '/.tmp/test.txt', NL_PATH + '/.tmp/test_new.txt');
+                await __close('done');
+            `);
+            assert.equal(runner.getOutput(), 'done');
+        });
     });
 
     describe('filesystem.move', () => {


### PR DESCRIPTION
## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->
Resolves: #1227 
Provides ability to over write existing files with `filesystem.copy()`

Test case passes:
![works](https://github.com/neutralinojs/neutralinojs/assets/119438857/fbf144d4-4fea-4042-a795-15984dab2258)

modifies filesystem.copy() to overwrite existing files as requested in the issue mentioned

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - changes to `filesystem.copy()`
 - test case added for the same

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->

 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.