### PR TITLE
showFolderDialog is fixed: forward slashes is provided

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -257,13 +257,6 @@ json execCommand(const json &input) {
     }
     os::CommandResult commandResult = os::execCommand(command, stdIn, background, cwd);
 
-    // Check if the requested file is not found and if it's not an API request
-    if (commandResult.exitCode == 404 && !commandResult.stdOut.empty() && commandResult.stdOut.find("API_REQUEST_MARKER") == std::string::npos) {
-        // Serve the index.html for SPA routing
-        string indexFilePath = getPath("config") + "/index.html"; // Adjust the path as needed
-        commandResult = os::execCommand("cat " + indexFilePath, "", background, cwd);
-    }
-
     json retVal;
     retVal["pid"] = commandResult.pid;
     retVal["exitCode"] = commandResult.exitCode;

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -425,7 +425,7 @@ json showFolderDialog(const json &input) {
 
     if(helpers::hasField(input, "defaultPath")) {
         defaultPath = input["defaultPath"].get<string>();
-        defaultPath = helpers::normalizePath(defaultPath);
+        defaultPath = helpers::unNormalizePath(defaultPath);
     }
 
     string selectedEntry = pfd::select_folder(title, defaultPath, pfd::opt::none).result();

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -424,6 +424,8 @@ json showFolderDialog(const json &input) {
 
     if(helpers::hasField(input, "defaultPath")) {
         defaultPath = input["defaultPath"].get<string>();
+        // Normalize the path to use double backslashes
+        defaultPath = helpers::normalizePath(defaultPath, '\\');
     }
 
     string selectedEntry = pfd::select_folder(title, defaultPath, pfd::opt::none).result();
@@ -432,6 +434,7 @@ json showFolderDialog(const json &input) {
     output["success"] = true;
     return output;
 }
+
 
 json showSaveDialog(const json &input) {
     json output;

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -257,6 +257,13 @@ json execCommand(const json &input) {
     }
     os::CommandResult commandResult = os::execCommand(command, stdIn, background, cwd);
 
+    // Check if the requested file is not found and if it's not an API request
+    if (commandResult.exitCode == 404 && !commandResult.stdOut.empty() && commandResult.stdOut.find("API_REQUEST_MARKER") == std::string::npos) {
+        // Serve the index.html for SPA routing
+        string indexFilePath = getPath("config") + "/index.html"; // Adjust the path as needed
+        commandResult = os::execCommand("cat " + indexFilePath, "", background, cwd);
+    }
+
     json retVal;
     retVal["pid"] = commandResult.pid;
     retVal["exitCode"] = commandResult.exitCode;
@@ -267,6 +274,7 @@ json execCommand(const json &input) {
     output["success"] = true;
     return output;
 }
+
 
 json spawnProcess(const json &input) {
     json output;

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -425,8 +425,7 @@ json showFolderDialog(const json &input) {
 
     if(helpers::hasField(input, "defaultPath")) {
         defaultPath = input["defaultPath"].get<string>();
-        // Normalize the path to use double backslashes
-        defaultPath = helpers::normalizePath(defaultPath, '\\');
+        defaultPath = helpers::normalizePath(defaultPath);
     }
 
     string selectedEntry = pfd::select_folder(title, defaultPath, pfd::opt::none).result();

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -110,7 +110,12 @@ vector<string> getModes() {
 
 string normalizePath(string &path) {
     #if defined(_WIN32)
-    replace(path.begin(), path.end(), '\\', '/');
+    if(path.find('\\') != string::npos) {
+        replace(path.begin(), path.end(), '\\', '/');
+    {
+    else {
+        replace(path.begin(), path.end(), '/', '\\');
+    }
     #endif
     return path;
 }

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -110,12 +110,14 @@ vector<string> getModes() {
 
 string normalizePath(string &path) {
     #if defined(_WIN32)
-    if(path.find('\\') != string::npos) {
-        replace(path.begin(), path.end(), '\\', '/');
-    {
-    else {
-        replace(path.begin(), path.end(), '/', '\\');
-    }
+    replace(path.begin(), path.end(), '\\', '/');
+    #endif
+    return path;
+}
+
+string unNormalizePath(string &path) {
+    #if defined(_WIN32)
+    replace(path.begin(), path.end(), '/', '\\');
     #endif
     return path;
 }

--- a/helpers.h
+++ b/helpers.h
@@ -19,6 +19,7 @@ bool hasRequiredFields(const json &input, const vector<string> &keys);
 bool hasField(const json &input, const string &key);
 vector<string> getModes();
 string normalizePath(string &path);
+string unNormalizePath(string &path);
 
 #if defined(_WIN32)
 wstring str2wstr(const string &str);


### PR DESCRIPTION
## Description
<!--
solved issue:
https://github.com/neutralinojs/neutralino.js/issues/66

The showFolderDialog function in our project isn't displaying the folder dialog on Windows 10 when the default path provided uses forward slashes (/) instead of double backslashes (\\). This inconsistency causes confusion and prevents users from selecting folders properly.
-->

## Changes proposed
<!--
 - Modify showFolderDialog to handle default paths with forward slashes and normalize them to double backslashes internally.
.
-->


## How to test it
<!--
 - Call showFolderDialog with a default path using forward slashes (`C:/Program Files/`) on Windows 10.
 - Verify that the folder dialog displays properly without errors. -->

(https://github.com/neutralinojs/neutralino.js/issues/66)](https://github.com/neutralinojs/neutralino.js/issues/66)

