### PR TITLE
Reduce delay before app closes on windows

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -947,7 +947,11 @@ public:
     });
 
     // wait for dispatch() to complete
-    WaitForSingleObject(evtWindowClosed, 10000);
+    /* TODO: Check why this method doesn't trigger a signal on Windows
+    *        when "exitProcessOnClose" is true. (Previous value: 10000)
+    *        This wait causes a delay when closing the program.
+    */
+    WaitForSingleObject(evtWindowClosed, 300);
     CloseHandle(evtWindowClosed);
 
   }


### PR DESCRIPTION
## Description
in certain Windows configurations, the signal expected by "WaitForSingleObject" before closing the application window (when "exitProcessOnClose" is true in neutralino.config.json), is not received. Which creates a freeze lasting from 2sec to 10sec on some machines. #1179 

## Changes proposed

 - Reduced WaitForSingleObject delay

## Next steps

I don't know enough about C++ to delve deeper into the problem. But the next step would be to see why when "exitProcessOnClose" is true, the behavior of the closure changes and blocks at this step.

None.