### PR TITLE
Add transparent windows support on Windows

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -881,7 +881,7 @@ public:
           });
       RegisterClassEx(&wc);
       m_window = CreateWindow(L"Neutralinojs_webview", L"", WS_OVERLAPPEDWINDOW, 99999999,
-                              CW_USEDEFAULT, 640, 480, nullptr, nullptr,
+                              CW_USEDEFAULT, 8000, 8000, nullptr, nullptr,
                               GetModuleHandle(nullptr), nullptr);
       SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
     } else {
@@ -889,6 +889,15 @@ public:
     }
 
     setDpi();
+
+    if (transparent) {
+      // remove other window styles and keep only the border
+      SetWindowLongPtr(m_window, GWL_STYLE, WS_THICKFRAME);
+      SetWindowLongPtr(m_window, GWL_EXSTYLE, GetWindowLongPtr(m_window, GWL_EXSTYLE) | WS_EX_LAYERED);
+
+      // transparent white, use of environment variable prevents flashing on show
+      SetEnvironmentVariable(L"WEBVIEW2_DEFAULT_BACKGROUND_COLOR", L"00FFFFFF");
+    }
 
     // stop the taskbar icon from showing by removing WS_EX_APPWINDOW.
     SetWindowLong(m_window, GWL_EXSTYLE, GetWindowLong(m_window, GWL_EXSTYLE) & ~WS_EX_APPWINDOW);


### PR DESCRIPTION
## Description
This enables support for transparent windows on Windows.
Resolves #1201.

![image](https://github.com/neutralinojs/neutralinojs/assets/1740382/f0feff1f-c562-44b1-8b8c-32242e06251a)

## Changes proposed
* Add WS_EX_LAYERED to GWL_EXSTYLE
* Overwrite GWL_STYLE and only keep WS_THICKFRAME, this in effect makes the window borderless, apart from the drag handles for resizing.
* Set the `WEBVIEW2_DEFAULT_BACKGROUND_COLOR` environment variable to make the WebView2 background transparent white.
* Set the initial window size to 8000x8000. There is an issue I haven't been able to figure out where the initial window size of a layered window dictates the active area of the window. This works around it for most cases, as most people don't have monitors with greater than 8k resolution.

## How to test it
Set `"transparent": true` in `neutralino.config.json`.
