### PR TITLE
Disable the default context menu (right mouse click)

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -548,6 +548,7 @@ void __createWindow() {
                     windowProps.sizeOptions.maxWidth, windowProps.sizeOptions.maxHeight,
                     windowProps.sizeOptions.resizable);
     nativeWindow->setEventHandler(&window::handlers::windowStateChange);
+    nativeWindow->setEnableContextMenu(windowProps.enableContextMenu);
 
     #if defined(__linux__) || defined(__FreeBSD__)
     windowHandle = (GtkWidget*) nativeWindow->window();
@@ -848,7 +849,7 @@ json init(const json &input) {
         windowProps.enableInspector = input["enableInspector"].get<bool>();
 
     if(helpers::hasField(input, "borderless"))
-        windowProps.borderless = input["borderless"].get<bool>();
+        windowProps.borderless = input["borderless"].get<bool>();    
 
     if(helpers::hasField(input, "maximize"))
         windowProps.maximize = input["maximize"].get<bool>();
@@ -863,10 +864,13 @@ json init(const json &input) {
         windowProps.transparent = input["transparent"].get<bool>();
 
     if(helpers::hasField(input, "exitProcessOnClose"))
-        windowProps.exitProcessOnClose = input["exitProcessOnClose"].get<bool>();
+        windowProps.exitProcessOnClose = input["exitProcessOnClose"].get<bool>();        
 
     if(helpers::hasField(input, "useSavedState"))
         windowProps.useSavedState = input["useSavedState"].get<bool>();
+
+    if(helpers::hasField(input, "enableContextMenu"))
+        windowProps.enableContextMenu = input["enableContextMenu"].get<bool>();
 
     __createWindow();
     output["success"] = true;

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -805,6 +805,18 @@ json setAlwaysOnTop(const json &input) {
     return output;
 }
 
+json enableContextMenu(const json &input) {
+    
+    json output;
+    bool enable = false;
+    if(helpers::hasField(input, "enable")) {
+        enable = input["enable"].get<bool>();
+    }
+    nativeWindow->setEnableContextMenu(enable);    
+    output["success"] = true;
+    return output; 
+}
+
 json getPosition(const json &input) {
     json output;
     json posRes;

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -118,6 +118,7 @@ json setSize(const json &input);
 json getSize(const json &input);
 json getPosition(const json &input);
 json setAlwaysOnTop(const json &input);
+json enableContextMenu(const json &input);
 
 } // namespace controllers
 

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -57,6 +57,7 @@ struct WindowOptions {
     bool transparent = false;
     bool exitProcessOnClose = true;
     bool useSavedState = true;
+    bool enableContextMenu = true;
     string title = "Neutralinojs";
     string url = "https://neutralino.js.org";
     string icon = "";

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -580,6 +580,7 @@ public:
   virtual void navigate(const std::string url) = 0;
   virtual void extend_user_agent(const std::string customAgent) = 0;
   virtual void resize(HWND) = 0;
+  virtual void setEnableContextMenu(bool) = 0;
 };
 
 //
@@ -615,6 +616,10 @@ public:
   void navigate(const std::string url) override {
     Uri uri(winrt::to_hstring(url));
     m_webview.Navigate(uri);
+  }
+
+  void setEnableContextMenu(bool enable) {
+    
   }
 
   void extend_user_agent(const std::string customAgent) {}
@@ -669,8 +674,9 @@ public:
             }
             else {
                 m_settings->put_AreDevToolsEnabled(FALSE);
-                m_settings->put_IsStatusBarEnabled(FALSE);
+                m_settings->put_IsStatusBarEnabled(FALSE);                
             }
+            
             flag.clear();
         }
     ));
@@ -700,6 +706,7 @@ public:
     CoTaskMemFree(ua);
   }
 
+
   void resize(HWND wnd) override {
     if (m_controller == nullptr) {
       return;
@@ -707,6 +714,12 @@ public:
     RECT bounds;
     GetClientRect(wnd, &bounds);
     m_controller->put_Bounds(bounds);
+  }
+
+  void setEnableContextMenu(bool enable) {
+    ICoreWebView2Settings *settings = nullptr;
+    m_webview->get_Settings(&settings);
+    settings->put_AreDefaultContextMenusEnabled(enable);
   }
 
   void navigate(const std::string url) override {
@@ -959,6 +972,10 @@ public:
     SetWindowText(m_window, str2wstr(title).c_str());
   }
 
+  void setEnableContextMenu(bool enable) {
+    m_browser->setEnableContextMenu(enable);
+  }
+
   std::string get_title() {
     int len = GetWindowTextLength(hwnd);
     std::wstring title;
@@ -1055,6 +1072,10 @@ public:
 
   void setEventHandler(eventHandler_t handler) {
     windowStateChange = handler;
+  }
+
+  void setEnableContextMenu(bool enable) {
+    browser_engine::setEnableContextMenu(enable);
   }
 
 };

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -580,7 +580,7 @@ public:
   virtual void navigate(const std::string url) = 0;
   virtual void extend_user_agent(const std::string customAgent) = 0;
   virtual void resize(HWND) = 0;
-  virtual void setEnableContextMenu(bool) = 0;
+  virtual void enableContextMenu(bool) = 0;
 };
 
 //
@@ -618,9 +618,7 @@ public:
     m_webview.Navigate(uri);
   }
 
-  void setEnableContextMenu(bool enable) {
-    
-  }
+  void enableContextMenu(bool enable) {}
 
   void extend_user_agent(const std::string customAgent) {}
 
@@ -716,9 +714,10 @@ public:
     m_controller->put_Bounds(bounds);
   }
 
-  void setEnableContextMenu(bool enable) {
+  void enableContextMenu(bool enable) override {
     ICoreWebView2Settings *settings = nullptr;
-    m_webview->get_Settings(&settings);
+    HRESULT hr = m_webview->get_Settings(&settings);
+    // Segmentation fault because of settings is nullptr!
     settings->put_AreDefaultContextMenusEnabled(enable);
   }
 
@@ -973,7 +972,7 @@ public:
   }
 
   void setEnableContextMenu(bool enable) {
-    m_browser->setEnableContextMenu(enable);
+    m_browser->enableContextMenu(enable);
   }
 
   std::string get_title() {

--- a/schemas/neutralino.config.schema.json
+++ b/schemas/neutralino.config.schema.json
@@ -17,7 +17,7 @@
           "type": "boolean",
           "description": "Enables or disables the native API. If you want to use any native API functions, you can set this option to 'true'.",
           "default": false
-        },
+        },        
         "tokenSecurity": {
           "type": "string",
           "description": "Neutralinojs uses a client-server communication pattern with a local WebSocket to handle native calls. This local server is protected with an auto-generated token. This option defines the security implementation for the token. \\n\\n Accepts the following values: \\n\\n - one-time (Recommended): Server sends the access token only once, and the client persists it in the sessionStorage. If another client (Eg: browser) tries to access the app, 'NE_RT_INVTOKN' error message will be shown instead of the application. Using this option is recommended since it reduces security issues. \\n\\n - none: Server sends the access token always, so any new client can see the application. \\n\\n ::: Danger: If you are using native APIs that can access your computer's internals such as 'os', 'filesystem', modules, never use 'none' option since any new client can use those APIs. :::",
@@ -98,7 +98,7 @@
         "globalVariables": {
           "type": "object",
           "description": "A key-value-based JavaScript object of custom global variables. \\n\\n You can make custom global variables too via 'neutralino.config.json', as shown below. \\n\\n \"globalVariables\": { \\n   \"TEST\": \"Test Value\" \\n } \\n\\n The above custom global variable's value can be accessed with 'NL_TEST'. You can set any data type for custom global variables. Look at the following examples. \\n\\n \"globalVariables\": { \\n   \"TEST_1\": 1, \\n   \"TEST_2\": null, \\n   \"TEST_3\": 3.5, \\n   \"TEST_4\": [3, 5, 4, 5], \\n   \"TEST_5\": { \\n     \"key\": \"value\", \\n     \"anotherKey\": 100 \\n   } \\n } \\n\\n Avoid overriding predefined global variables. \\n\\n Learn more about this option here: \\n https://github.com/neutralinojs/neutralinojs.github.io/blob/main/docs/api/global-variables.md#custom-global-variables"
-        },
+        },        
         "logging": {
           "type": "object",
           "additionalProperties": false,
@@ -236,6 +236,11 @@
                     "exitProcessOnClose": {
                       "type": "boolean",
                       "description": "If this setting is 'true', the app process will exit when the user clicks on the close button. Otherwise, the framework will dispatch the 'windowClose' event."
+                    },
+                    "enableContextMenu": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Enables of disables the default right mouse click context menu. When no value is defined, the context is enabled by default"
                     }
                   }
                 }

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -66,6 +66,7 @@ map<string, router::NativeMethod> methodMap = {
     {"window.getSize", window::controllers::getSize},
     {"window.getPosition", window::controllers::getPosition},
     {"window.setAlwaysOnTop", window::controllers::setAlwaysOnTop},
+    {"window.enableContextMenu", window::controllers::enableContextMenu},
     // Neutralino.computer
     {"computer.getMemoryInfo", computer::controllers::getMemoryInfo},
     {"computer.getArch", computer::controllers::getArch},


### PR DESCRIPTION
## Description
As discussed [here](https://github.com/neutralinojs/neutralinojs/discussions/630) I thought the ability to disable the default context menu would be useful. 
Unfortunately I can only test on windows so I would appreciate if someone could help me out with Linux/Mac.

## Changes proposed
Added an option to the neutralino config to enable/disable the context menu

## How to test it
- run Neutralino with this window option set: `enableContextMenu: false`
- no context menu opens when making a right mouse click

## Next steps
- Vote if this pull request should be merged as soon as the feature is completed
- Implement client library command
- Test on Linux/Mac


## Deploy notes
None.