### PR TITLE
Neutralinojs Compilation Error on Windows 11

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -213,7 +213,7 @@ string getPath(const string &name) {
     else if(name == "saveGames2")
         path = sago::getSaveGamesFolder2();
     else if(name == "temp")
-        path = filesystem::temp_directory_path();
+        path = filesystem::temp_directory_path().string();
     return helpers::normalizePath(path);
 }
 


### PR DESCRIPTION
## Description
    Neutralinojs Compilation Error on Windows 11
![Screenshot 2024-07-25 165350](https://github.com/user-attachments/assets/b706572e-a9fb-42f2-adfe-eb3e252d9591)

## Changes proposed
 - Change the filesystem::temp_directory_path() to string

## How to test it

 - Run python scripts/bz.py