### PR TITLE
Fix: Write Image to Clipboard on Windows

### DIFF
--- a/api/clipboard/clipboard.cpp
+++ b/api/clipboard/clipboard.cpp
@@ -64,6 +64,8 @@ json readImage(const json &input) {
             { "redShift", spec.red_shift },
             { "greenShift", spec.green_shift },
             { "blueShift", spec.blue_shift },
+            { "alphaMask", spec.alpha_mask },
+            { "alphaShift", spec.alpha_shift },
             { "data", base64::to_base64(clipData) }
         };
     }
@@ -75,9 +77,9 @@ json readImage(const json &input) {
 
 json writeImage(const json &input) {
     json output;
-    if(!helpers::hasRequiredFields(input,
-            {"width", "height", "bpp", "bpr", "redMask", "greenMask", "blueMask",
-            "redShift", "greenShift", "blueShift", "data"})) {
+    if (!helpers::hasRequiredFields(input,
+        { "width", "height", "bpp", "bpr", "redMask", "greenMask", "blueMask",
+        "redShift", "greenShift", "blueShift", "data", "alphaShift", "alphaMask"})) {
         output["error"] = errors::makeMissingArgErrorPayload();
         return output;
     }
@@ -92,7 +94,8 @@ json writeImage(const json &input) {
     spec.red_shift = input["redShift"].get<unsigned long>();
     spec.green_shift = input["greenShift"].get<unsigned long>();
     spec.blue_shift = input["blueShift"].get<unsigned long>();
-    spec.width = input["width"].get<unsigned long>();
+    spec.alpha_mask = input["alphaMask"].get<unsigned long>();
+    spec.alpha_shift = input["alphaShift"].get<unsigned long>();
 
     string clipData = base64::from_base64(input["data"].get<string>());
     clip::image image(clipData.data(), spec);


### PR DESCRIPTION
## Description
 It fixes the working of writeImage() function In Windows 11.

## Before
Black Image is written to the clipboard.
![Screenshot 2024-07-25 171312](https://github.com/user-attachments/assets/c78e85e0-5272-4c14-ada9-c100133a852b)
## After
Image with all the specs is written properly to the clipboard
![Screenshot 2024-07-25 171606](https://github.com/user-attachments/assets/abad9b5c-1746-4e8b-9570-c6a1ad66e307)
* The Latest image is the one written in the clipboard


## Changes proposed
 - Added the Alpha Mask and Alpha Shift to the image object in the Read Image Function
 - Set the Alpha Mask and Alpha Shift to the image spec in the Write Image Function

## How to test it
    async function WriteImage() {
     const image = await Neutralino.clipboard.readImage();
     console.log(image);
     const result = await Neutralino.clipboard.writeImage(image);
     console.log(result);
    }

