### PR TITLE
Create a focusable option

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -540,7 +540,7 @@ namespace controllers {
 void __createWindow() {
     savedState = windowProps.useSavedState && __loadSavedWindowProps();
 
-    nativeWindow = new webview::webview(windowProps.enableInspector, nullptr, windowProps.transparent);
+    nativeWindow = new webview::webview(windowProps.enableInspector, nullptr, windowProps.transparent, windowProps.focusable);
     nativeWindow->set_title(windowProps.title);
     if(windowProps.extendUserAgentWith != "") {
         nativeWindow->extend_user_agent(windowProps.extendUserAgentWith);
@@ -870,6 +870,9 @@ json init(const json &input) {
 
     if(helpers::hasField(input, "useSavedState"))
         windowProps.useSavedState = input["useSavedState"].get<bool>();
+
+    if(helpers::hasField(input, "focusable"))
+        windowProps.focusable = input["focusable"].get<bool>();
 
     __createWindow();
     output["success"] = true;

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -63,6 +63,7 @@ struct WindowOptions {
     string extendUserAgentWith = "";
     int x = 0;
     int y = 0;
+    bool focusable = false;
 };
 
 namespace handlers {

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -791,7 +791,7 @@ private:
 
 class win32_edge_engine {
 public:
-  win32_edge_engine(bool debug, void *window, bool transparent) {
+  win32_edge_engine(bool debug, void *window, bool transparent, bool focusable = true) {
     if (window == nullptr) {
       HINSTANCE hInstance = GetModuleHandle(nullptr);
       HICON icon = (HICON)LoadImage(
@@ -882,7 +882,7 @@ public:
       RegisterClassEx(&wc);
       int width = transparent ? 8000 : 640;
       int height = transparent ? 8000 : 480;
-      m_window = CreateWindow(L"Neutralinojs_webview", L"", WS_OVERLAPPEDWINDOW, 99999999,
+      m_window = CreateWindowEx(focusable ? WS_EX_LEFT : WS_EX_NOACTIVATE | WS_EX_TOPMOST, L"Neutralinojs_webview", L"", WS_OVERLAPPEDWINDOW, 99999999,
                               CW_USEDEFAULT, width, height, nullptr, nullptr,
                               GetModuleHandle(nullptr), nullptr);
       SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
@@ -1054,8 +1054,8 @@ namespace webview {
 
 class webview : public browser_engine {
 public:
-  webview(bool debug = false, void *wnd = nullptr, bool transparent = false)
-      : browser_engine(debug, wnd, transparent) {}
+  webview(bool debug = false, void *wnd = nullptr, bool transparent = false, bool focusable = true)
+      : browser_engine(debug, wnd, transparent, focusable) {}
 
   void navigate(const std::string url) {
     browser_engine::navigate(url);

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -882,7 +882,7 @@ public:
       RegisterClassEx(&wc);
       int width = transparent ? 8000 : 640;
       int height = transparent ? 8000 : 480;
-      m_window = CreateWindowEx(focusable ? WS_EX_LEFT : WS_EX_NOACTIVATE | WS_EX_TOPMOST, L"Neutralinojs_webview", L"", WS_OVERLAPPEDWINDOW, 99999999,
+      m_window = CreateWindowEx(focusable ? WS_EX_LEFT : WS_EX_NOACTIVATE, L"Neutralinojs_webview", L"", WS_OVERLAPPEDWINDOW, 99999999,
                               CW_USEDEFAULT, width, height, nullptr, nullptr,
                               GetModuleHandle(nullptr), nullptr);
       SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);

--- a/settings.cpp
+++ b/settings.cpp
@@ -252,6 +252,7 @@ void applyConfigOverride(const settings::CliArg &arg) {
         {"--window-use-saved-state", {"/modes/window/useSavedState", "bool"}},
         {"--window-icon", {"/modes/window/icon", "string"}},
         {"--window-extend-user-agent-with", {"/modes/window/extendUserAgentWith", "string"}},
+        {"--window-focusable", {"/modes/window/focusable", "bool"}},
         // Chrome mode
         {"--chrome-width", {"/modes/chrome/width", "int"}},
         {"--chrome-height", {"/modes/chrome/height", "int"}},


### PR DESCRIPTION
## Description
This change creates an option, like transparent, that makes the window have the WS_EX_NOACTIVATE style. That means the window doesn't activate when opened, can't be focused when clicking and doesn't appear in the task bar. This is useful for notifications.

## Changes proposed
- Added a "focusable" option to the configuration
- Modified Webview.h to create a focusable window based on the attribute

## How to test it
I'm not sure this is testable, at least I don't know how to test for this

 - Run specs/tests

## Next steps
The next steps would be to create functions like "setFocusable", like with the topmost option.

## Deploy notes
My first PR, feel free to comment on code quality etc. Ty <3