### PR TITLE
GSoC2024: TestSuite - version 5.3.0

### DIFF
--- a/spec/filesystem.spec.js
+++ b/spec/filesystem.spec.js
@@ -48,16 +48,6 @@ describe('filesystem.spec: filesystem namespace tests', () => {
             `);
             assert.equal(runner.getOutput(), 'NE_FS_DIRCRER');
         });
-
-        it('works with special characters', async () => {
-            runner.run(`
-                await Neutralino.filesystem.createDirectory(NL_PATH + '/.tmp/@#$%^&*☁☀☊☄');
-                let entries = await Neutralino.filesystem.readDirectory(NL_PATH + '/.tmp');
-                await __close(JSON.stringify(entries));
-            `);
-            const entries = JSON.parse(runner.getOutput());
-            assert.ok(entries.find((entry) => entry.type == 'DIRECTORY' && entry.entry == '@#$%^&*☁☀☊☄'));
-        });
     });
 
     describe('filesystem.remove', () => {

--- a/spec/filesystem.spec.js
+++ b/spec/filesystem.spec.js
@@ -48,6 +48,16 @@ describe('filesystem.spec: filesystem namespace tests', () => {
             `);
             assert.equal(runner.getOutput(), 'NE_FS_DIRCRER');
         });
+
+        it('works with special characters', async () => {
+            runner.run(`
+                await Neutralino.filesystem.createDirectory(NL_PATH + '/.tmp/@#$%^&*☁☀☊☄');
+                let entries = await Neutralino.filesystem.readDirectory(NL_PATH + '/.tmp');
+                await __close(JSON.stringify(entries));
+            `);
+            const entries = JSON.parse(runner.getOutput());
+            assert.ok(entries.find((entry) => entry.type == 'DIRECTORY' && entry.entry == '@#$%^&*☁☀☊☄'));
+        });
     });
 
     describe('filesystem.remove', () => {
@@ -1092,6 +1102,195 @@ describe('filesystem.spec: filesystem namespace tests', () => {
             assert.ok(typeof watchers[0] == 'object');
             assert.ok(typeof watchers[0].id == 'number');
             assert.ok(typeof watchers[0].path == 'string');
+        });
+    });
+    
+    describe('filesystem.getRelativePath', () => {
+        it('returns an error if the path field is missing', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.filesystem.getRelativePath();
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `);
+            assert.equal(runner.getOutput(), 'NE_RT_NATRTER');
+        });
+
+        it('calculates relative path with a custom base path', async () => {
+            runner.run(`
+                let base = NL_PATH + '/.tmp';
+                await Neutralino.filesystem.writeFile(NL_PATH + '/.tmp/test.txt', 'Dummy content');
+                let response = await Neutralino.filesystem.getRelativePath(NL_PATH + '/.tmp/test.txt', base);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.equal(output, 'test.txt');
+        });
+    
+        it('handles paths that are equal to the base path', async () => {
+            runner.run(`
+                let base = NL_PATH + '/folder';
+                await Neutralino.filesystem.writeFile(NL_PATH + '/folder', 'Dummy content');
+                let response = await Neutralino.filesystem.getRelativePath(NL_PATH + '/folder', NL_PATH + '/folder');
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.equal(output, '.');
+        });
+    });
+
+    describe('filesystem.getPathParts', () => {
+        it('returns path parts for a valid file path with no extension', async () => {
+            runner.run(`
+                let path = NL_PATH + '/folder/file';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '',
+                filename: 'file',
+                parentPath: '../bin/folder',
+                relativePath: '../bin/folder/file',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: 'file'
+              });
+        });
+    
+        it('returns path parts for a file path with a single dot extension', async () => {
+            runner.run(`
+                let path = NL_PATH + '/folder/.hiddenfile';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '',
+                filename: '.hiddenfile',
+                parentPath: '../bin/folder',
+                relativePath: '../bin/folder/.hiddenfile',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: '.hiddenfile'
+              });
+        });
+    
+        it('returns path parts for a path with special characters', async () => {
+            runner.run(`
+                let path = NL_PATH + '/folder/special@file#name.txt';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '.txt',
+                filename: 'special@file#name.txt',
+                parentPath: '../bin/folder',
+                relativePath: '../bin/folder/special@file#name.txt',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: 'special@file#name'
+              });
+        });
+    
+        it('returns path parts for a root path', async () => {
+            runner.run(`
+                let path = NL_PATH;
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '',
+                filename: 'bin',
+                parentPath: '..',
+                relativePath: '../bin',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: 'bin'
+              });
+        });
+    
+        it('returns path parts for a path with a root directory', async () => {
+            runner.run(`
+                let path = NL_PATH + '/root/directory/file.txt';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '.txt',
+                filename: 'file.txt',
+                parentPath: '../bin/root/directory',
+                relativePath: '../bin/root/directory/file.txt',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: 'file'
+              });
+        });
+    
+        it('returns path parts for a path with multiple nested directories', async () => {
+            runner.run(`
+                let path = NL_PATH + '/nested/dir/structure/file.ext';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '.ext',
+                filename: 'file.ext',
+                parentPath: '../bin/nested/dir/structure',
+                relativePath: '../bin/nested/dir/structure/file.ext',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: 'file'
+              });
+        });
+    
+        it('returns path parts for a path with a filename that starts with a dot', async () => {
+            runner.run(`
+                let path = NL_PATH + '/folder/.config/file.txt';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '.txt',
+                filename: 'file.txt',
+                parentPath: '../bin/folder/.config',
+                relativePath: '../bin/folder/.config/file.txt',
+                rootDirectory: '',
+                rootName: '',
+                rootPath: '',
+                stem: 'file'
+              });
+        });
+    
+        it('returns path parts for a path with absolute path separators', async () => {
+            runner.run(`
+                let path = '/absolute/path/to/file.txt';
+                let response = await Neutralino.filesystem.getPathParts(path);
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.deepEqual(output, {
+                extension: '.txt',
+                filename: 'file.txt',
+                parentPath: '/absolute/path/to',
+                relativePath: 'absolute/path/to/file.txt',
+                rootDirectory: '/',
+                rootName: '',
+                rootPath: '/',
+                stem: 'file'
+              });
         });
     });
 });

--- a/spec/os.spec.js
+++ b/spec/os.spec.js
@@ -535,12 +535,11 @@ describe('os.spec: os namespace tests', () => {
             runner.run(`
                 let documentsPath;
                 documentsPath = await Neutralino.os.getPath('documents');
-                console.log('Documents path:', documentsPath);
                 await __close(documentsPath);
             `);
             let output = runner.getOutput().trim();
             let normalizedOutput = path.normalize(output);
-            let isValidPath = path.isAbsolute(normalizedOutput) && normalizedOutput === output;
+            let isValidPath = path.isAbsolute(normalizedOutput);
             assert.ok(isValidPath);
         });
 

--- a/spec/os.spec.js
+++ b/spec/os.spec.js
@@ -335,12 +335,12 @@ describe('os.spec: os namespace tests', () => {
         });
     
         it('retrieves value with special characters', async () => {
-            process.env.SPECIAL_VAR = '@#$%^&*';
+            process.env.SPECIAL_VAR = '@#$%^&*☊☄';
             runner.run(`
                 let value = await Neutralino.os.getEnv('SPECIAL_VAR');
                 await __close(value);
             `);
-            assert.equal(runner.getOutput(), '@#$%^&*');
+            assert.equal(runner.getOutput(), '@#$%^&*☊☄');
         });
     });
 
@@ -540,7 +540,7 @@ describe('os.spec: os namespace tests', () => {
             `);
             let output = runner.getOutput().trim();
             let normalizedOutput = path.normalize(output);
-            let isValidPath = path.isAbsolute(normalizedOutput);
+            let isValidPath = path.isAbsolute(normalizedOutput) && normalizedOutput === output;
             assert.ok(isValidPath);
         });
 


### PR DESCRIPTION
## Description
This PR adds test cases for the new version changes

## Changes proposed
- filesystem.createDirectory()
- [x] works with special characters
- filesystem.getRelativePath()
- [x] returns an error if the path field is missing
- [x] calculates relative path with a custom base path
- [x] handles paths that are equal to the base path
- filesystem.getPathParts()
- [x] returns path parts for a valid file path with no extension
- [x] returns path parts for a file path with a single dot extension
- [x] returns path parts for a path with special characters
- [x] returns path parts for a root path
- [x] returns path parts for a path with a root directory
- [x] returns path parts for a path with multiple nested directories
- [x] returns path parts for a path with a filename that starts with a dot
- [x] returns path parts for a path with absolute path separators
- os.getEnv()
- [x] retrieves value with special characters
- os.getPath()
- [x] returns a valid path

## How to test it

 - Run `cd spec && rpm test filesystem`
 - Run `cd spec && rpm test os`