### PR TITLE
Fix #1316

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <vector>
 #include <filesystem>
+#include <atomic>
+#include <climits>
 
 #include "resources.h"
 #include "lib/tinyprocess/process.hpp"
@@ -63,6 +65,7 @@ bool useOtherTempTrayIcon = true;
 #endif
 map<int, TinyProcessLib::Process*> spawnedProcesses;
 mutex spawnedProcessesLock;
+atomic<int> nextVirtualPid(0);
 
 void __dispatchSpawnedProcessEvt(int virtualPid, const string &action, const json &data) {
     json evt;
@@ -137,7 +140,11 @@ pair<int, int> spawnProcess(string command, const string &cwd) {
 
     TinyProcessLib::Process *childProcess;
     lock_guard<mutex> guard(spawnedProcessesLock);
-    int virtualPid = spawnedProcesses.size();
+    int virtualPid = nextVirtualPid.fetch_add(1);
+
+    if (virtualPid == INT_MIN) {
+        virtualPid = nextVirtualPid.exchange(0);
+    }
 
     childProcess = new TinyProcessLib::Process(
         CONVSTR(command), CONVSTR(cwd),

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -140,10 +140,10 @@ pair<int, int> spawnProcess(string command, const string &cwd) {
 
     TinyProcessLib::Process *childProcess;
     lock_guard<mutex> guard(spawnedProcessesLock);
-    int virtualPid = nextVirtualPid.fetch_add(1);
 
-    if (virtualPid == INT_MIN) {
-        virtualPid = nextVirtualPid.exchange(0);
+    int virtualPid = nextVirtualPid.fetch_add(1);
+    if (virtualPid == INT_MAX) {
+        nextVirtualPid.store(0);
     }
 
     childProcess = new TinyProcessLib::Process(

--- a/spec/os.spec.js
+++ b/spec/os.spec.js
@@ -74,6 +74,23 @@ describe('os.spec: os namespace tests', () => {
             assert.ok(vids[1].pid > 0);
         });
 
+        it('assigns a unique virtual pid to each process', async () => {
+            runner.run(`
+                let ids = [];
+                for (let i = 0; i < 10; i++) {
+                    let proc = await Neutralino.os.spawnProcess('node -e "setTimeout(() => {}, 5000);"');
+                    ids.push(proc.id);
+                    if (i % 2 === 0) {
+                        await Neutralino.os.updateSpawnedProcess(proc.id, 'exit');
+                    }
+                }
+                await __close(JSON.stringify(ids));
+            `);
+
+            const ids = JSON.parse(runner.getOutput());
+            const hasDuplicates = ids.some((id, index) => ids.indexOf(id) !== index);
+            assert.ok(!hasDuplicates);
+        });
 
         it('sends the exit code with the exit action via the spawnProcess event', async () => {
             runner.run(`


### PR DESCRIPTION
## Description

This change aims to eliminate ID collision in the `os.spawnProcess()` method. See #1316

## Changes proposed

- Introduce an incrementing counter in lieu of `map::size()` for virtual process IDs
- Add a test case to check for unique IDs

## How to test it

- Run the new test case added to `os.spec.js`

## Next steps

None.

## Deploy notes

None.
