### PR TITLE
Update buildzri.config.json

### DIFF
--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -49,14 +49,15 @@
     },
     "options": {
         "linux": [
-            "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 glib-2.0 xcb x11 xrandr)",
-            "-pthread",
-            "-lpng",
-            "-lstdc++fs",
-            "-ldl",
-            "-no-pie",
-            "-Os"
-        ],
+    "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1 glib-2.0 xcb x11 xrandr)",
+    "-pthread",
+    "-lpng",
+    "-lstdc++fs",
+    "-ldl",
+    "-no-pie",
+    "-Os"
+],
+
         "darwin": [
             "-Wno-deprecated-declarations",
             "-framework WebKit",

--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -49,15 +49,14 @@
     },
     "options": {
         "linux": [
-    "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1 glib-2.0 xcb x11 xrandr)",
-    "-pthread",
-    "-lpng",
-    "-lstdc++fs",
-    "-ldl",
-    "-no-pie",
-    "-Os"
-],
-
+            "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1 glib-2.0 xcb x11 xrandr)",
+            "-pthread",
+            "-lpng",
+            "-lstdc++fs",
+            "-ldl",
+            "-no-pie",
+            "-Os"
+        ],
         "darwin": [
             "-Wno-deprecated-declarations",
             "-framework WebKit",


### PR DESCRIPTION
Currently targeting webkit2gtk-4.0. Now edited the file to target the new version webkit2gtk-4.1

## Description
<!--
   So this is regarding the issue #1307. When running a neutralino app in Fedora 40, if you have just webkitgtk 4.1 installed and not webkitgtk 4.0 it throws error. So using the latest version should resolve this issue
-->

## Changes proposed
<!--
     "linux": [
    "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 glib-2.0 xcb x11 xrandr)",
to latest one:
 "linux": [
    "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1 glib-2.0 xcb x11 xrandr)",
-->


