### PR TITLE
Bump Linux webkit2gtk to 4.1

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     strategy:
       matrix:
@@ -25,8 +25,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y -f \
         libgtk-3-dev \
-        libwebkit2gtk-4.0-37 \
-        libwebkit2gtk-4.0-dev
+        libwebkit2gtk-4.1-0 \
+        libwebkit2gtk-4.1-dev
 
     - name: Build
       if: ${{ matrix.arch == 'x64' }}
@@ -38,12 +38,12 @@ jobs:
       id: build-package
       with:
         arch: ${{ matrix.arch == 'arm64' && 'aarch64' || 'armv7' }}
-        distro: ubuntu20.04
+        distro: ubuntu22.04
         install: |
           apt-get update
           apt-get install -y -f \
           libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
+          libwebkit2gtk-4.1-dev \
           git \
           python3 \
           g++ \

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     strategy:
       matrix:
@@ -22,8 +22,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y -f \
         libgtk-3-dev \
-        libwebkit2gtk-4.0-37 \
-        libwebkit2gtk-4.0-dev
+        libwebkit2gtk-4.1-0 \
+        libwebkit2gtk-4.1-dev
         
     - name: Build
       if: ${{ matrix.arch == 'x64' }}
@@ -35,12 +35,12 @@ jobs:
       id: build-package
       with:
         arch: ${{ matrix.arch == 'arm64' && 'aarch64' || 'armv7' }}
-        distro: ubuntu20.04
+        distro: ubuntu22.04
         install: |
           apt-get update
           apt-get install -y -f \
           libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
+          libwebkit2gtk-4.1-dev \
           git \
           python3 \
           g++ \

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     strategy:
       matrix:
@@ -20,8 +20,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y -f \
         libgtk-3-dev \
-        libwebkit2gtk-4.0-37 \
-        libwebkit2gtk-4.0-dev \
+        libwebkit2gtk-4.1-0 \
+        libwebkit2gtk-4.1-dev \
         libayatana-appindicator3-1 \
         xvfb
 
@@ -37,12 +37,12 @@ jobs:
       id: build-package
       with:
         arch: ${{ matrix.arch == 'arm64' && 'aarch64' || 'armv7' }}
-        distro: ubuntu20.04
+        distro: ubuntu22.04
         install: |
           apt-get update
           apt-get install -y -f \
           libgtk-3-dev \
-          libwebkit2gtk-4.0-dev \
+          libwebkit2gtk-4.1-dev \
           git \
           python3 \
           g++ \

--- a/buildzri.config.json
+++ b/buildzri.config.json
@@ -49,7 +49,7 @@
     },
     "options": {
         "linux": [
-            "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 glib-2.0 xcb x11 xrandr)",
+            "$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1 glib-2.0 xcb x11 xrandr)",
             "-pthread",
             "-lpng",
             "-lstdc++fs",


### PR DESCRIPTION
## Description
Updates `webkit2gtk` on Ubuntu boxes to 4.1 instead of 4.0 - fixes #1307 

This is a duplicate of PR #1320 but I'm getting impatient

## Changes proposed

- change webkit2gtk in GitHub Actions to 4.1 (over 4.0)
- update `buildzri.config.json` to use `webkit2gtk` 4.1

## How to test it

- Run GitHub actions
