### PR TITLE
Fix neu devtools extension condition

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -183,7 +183,7 @@ void setGlobalArgs(const json &args) {
 
         // Enable dev tools connection (as an extension)
         // Not available for production (resources.neu-based) apps
-        if(cliArg.key == "--neu-dev-extension" && resources::isBundleMode()) {
+        if(cliArg.key == "--neu-dev-extension" && !resources::isBundleMode()) {
             extensions::loadOne("js.neutralino.devtools");
             continue;
         }


### PR DESCRIPTION
## Description

This change will allow the devtools extension to connect when the Neutralino app is in development configuration.

## Changes proposed

- Flip the conditional statement in `settings.cpp` to `!resources::isBundleMode()`

## How to test it

 - Run a frontend library app that requires a devtools connection to patch the HTML file

## Next steps

None.

## Deploy notes

None.