### PR TITLE
fixed bug causing syntax error while running build cmd

### DIFF
--- a/bin/resources/js/main_spec.js
+++ b/bin/resources/js/main_spec.js
@@ -1,0 +1,37 @@
+
+
+
+Neutralino.init();
+
+Neutralino.events.on("ready", async () => {
+    await __init();
+    
+                function onTestEvent(evt) {
+                    __close('done');
+                }
+                await Neutralino.events.on('testEvent', onTestEvent);
+                await Neutralino.events.broadcast('testEvent');
+            
+});
+
+async function __close(data = "", exitCode = 0) {
+    if(data) {
+        await Neutralino.filesystem.writeFile(NL_PATH + "/.tmp/output.txt", data);
+    }
+    setTimeout(async () => {
+        await Neutralino.app.exit(exitCode); // normal exit
+    }, 2000);
+}
+
+async function __init() {
+    try {
+        await Neutralino.filesystem.createDirectory(NL_PATH + "/.tmp");
+    }
+    catch(err) {
+        // ignore
+    }
+    setTimeout(async () => {
+        await Neutralino.filesystem.writeFile(NL_PATH + "/.tmp/output.txt", 'NL_SP_MAXTIMT');
+        await Neutralino.app.exit(1); // max timeout force exit
+    }, 20000);
+}

--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -240,7 +240,7 @@ def compile(cmd):
     sys.exit(exit_code)
 
 def print_ascii_art():
-    print('''
+    print(r'''
   ____        _ _     _ ______     _
  |  _ \      (_) |   | |___  /    (_)
  | |_) |_   _ _| | __| |  / / _ __ _


### PR DESCRIPTION
The issue  (SyntaxWarning: invalid escape sequence '\ ') is fixed.  By making the string literal raw by adding an r prefix to the triple-quoted string. Hope that solves the bug.