### PR TITLE
commiting bz.py and fixing the bug that caused syntax error/Bxpx6

### DIFF
--- a/scripts/bz.py
+++ b/scripts/bz.py
@@ -240,7 +240,7 @@ def compile(cmd):
     sys.exit(exit_code)
 
 def print_ascii_art():
-    print('''
+    print(r'''
   ____        _ _     _ ______     _
  |  _ \      (_) |   | |___  /    (_)
  | |_) |_   _ _| | __| |  / / _ __ _


### PR DESCRIPTION
## Description
<!--
    As requested the main_specs.js file is note included in the commit
-->

## Changes proposed
<!--
the changes proposed are commited -->
The bug is fixed 
The issue (SyntaxWarning: invalid escape sequence '\ ') is fixed. By making the string literal raw by adding an r prefix to the triple-quoted string. Hope that solves the bug.



