### PR TITLE
Fix: Ensure window.getTitle() works on Windows platform

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1091,10 +1091,10 @@ public:
   }
 
   std::string get_title() {
-      int len = GetWindowTextLengthW(m_window);
+      int len = GetWindowTextLength(m_window);
       if (len == 0) return "";
       std::wstring title(len + 1, 0);
-      if (!GetWindowTextW(m_window, &title[0], len + 1)) return "";
+      if (!GetWindowText(m_window, &title[0], len + 1)) return "";
       title.resize(len);
       return wstr2str(title);
   }

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1091,11 +1091,12 @@ public:
   }
 
   std::string get_title() {
-    int len = GetWindowTextLength(hwnd);
-    std::wstring title;
-    title.reserve(len + 1);
-    GetWindowText(hwnd, const_cast<WCHAR *>(title.c_str()), title.capacity());
-    return wstr2str(title);
+      int len = GetWindowTextLengthW(m_window);
+      if (len == 0) return "";
+      std::wstring title(len + 1, 0);
+      if (!GetWindowTextW(m_window, &title[0], len + 1)) return "";
+      title.resize(len);
+      return wstr2str(title);
   }
 
   void set_size(int width, int height, int minWidth, int minHeight,

--- a/spec/window.spec.js
+++ b/spec/window.spec.js
@@ -15,12 +15,13 @@ describe('window.spec: window namespace tests', () => {
     });
 
     describe('window.getTitle', () => {
-        it('returns a string value', async () => {
+        it('checks title value', async () => {
             runner.run(`
+                await Neutralino.window.setTitle("NeutralinoJs");
                 let title = await Neutralino.window.getTitle();
                 await __close(JSON.stringify({out: title}));
             `);
-            assert.ok(typeof JSON.parse(runner.getOutput()).out == 'string');
+            assert.ok(JSON.parse(runner.getOutput()).out === "NeutralinoJs");
         });
     });
 

--- a/spec/window.spec.js
+++ b/spec/window.spec.js
@@ -15,13 +15,13 @@ describe('window.spec: window namespace tests', () => {
     });
 
     describe('window.getTitle', () => {
-        it('checks title value', async () => {
+        it('returns the existing title string', async () => {
             runner.run(`
-                await Neutralino.window.setTitle("NeutralinoJs");
+                await Neutralino.window.setTitle('NeutralinoJs');
                 let title = await Neutralino.window.getTitle();
-                await __close(JSON.stringify({out: title}));
+                await __close(title);
             `);
-            assert.ok(JSON.parse(runner.getOutput()).out === "NeutralinoJs");
+            assert.ok(runner.getOutput() === 'NeutralinoJs');
         });
     });
 


### PR DESCRIPTION
### Problem
The `window.getTitle()` function was returning an empty string on the Windows platform, as reported in the [neutralinojs/neutralino.js#123](https://github.com/neutralinojs/neutralino.js/issues/123) repository.

### Root Cause
The issue was caused by an incorrect implementation in the `get_title()` function within the `WEBVIEW_EDGE` section of `webview.h`. The function did not handle the string correctly and passed the wrong `HWND` to the `GetWindowText` function, resulting in an empty string being returned.

### Fix
The implementation of `get_title()` was updated to correctly retrieve the window title & tested on windows.
