### PR TITLE
✨ app.mount, app.unmount for hosting files from filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![Build status](https://github.com/neutralinojs/neutralinojs/actions/workflows/test_suite.yml/badge.svg)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fneutralinojs%2Fneutralinojs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fneutralinojs%2Fneutralinojs?ref=badge_shield)
 
-Neutralinojs is a lightweight and portable desktop application development framework. It lets you develop lightweight cross-platform desktop applications using JavaScript, HTML and CSS. Apps built with Neutralinojs can run on Linux, macOS, Windows, Web, and Chrome. Also, you can extend Neutralinojs with any programming language (via extensions IPC) and use Neutralinojs as a part of any source file (via child processes IPC). 
+Neutralinojs is a lightweight and portable desktop application development framework. It lets you develop lightweight cross-platform desktop applications using JavaScript, HTML and CSS. Apps built with Neutralinojs can run on Linux, macOS, Windows, Web, and Chrome. Also, you can extend Neutralinojs with any programming language (via extensions IPC) and use Neutralinojs as a part of any source file (via child processes IPC).
 
 - [Neutralinojs vs. Electron, NW.JS, Tauri, NodeGui, Flutter, .Net MAUI, Wails](https://github.com/Elanis/web-to-desktop-framework-comparison)
 - [Neutralinojs vs. Electron vs. NW.js (2018)](https://github.com/neutralinojs/evaluation)
@@ -21,14 +21,14 @@ Neutralinojs is a lightweight and portable desktop application development frame
 Get started with the neu CLI:
 
 ```bash
- # Creating a new app
- npm i -g @neutralinojs/neu
- neu create hello-world
- cd hello-world
- neu run
- 
- # Building your app (No compilation - takes less than a second)
- neu build
+# Creating a new app
+npm i -g @neutralinojs/neu
+neu create hello-world
+cd hello-world
+neu run
+
+# Building your app (No compilation - takes less than a second)
+neu build
 ```
 
 You can use your favorite frontend frameworks:
@@ -39,8 +39,8 @@ neu create hello-react -t codezri/neutralinojs-react
 ```
 
 Start building apps: [neutralino.js.org/docs](https://neutralino.js.org/docs)
- 
-## Why Neutralinojs? 
+
+## Why Neutralinojs?
 
 In Electron and NWjs, you have to install NodeJs and hundreds of dependency libraries. Embedded Chromium and Node make simple apps bloaty. Neutralinojs offers a lightweight and portable SDK which is an alternative for Electron and NW.js. Neutralinojs doesn't bundle Chromium and uses the existing web browser library in the operating system (Eg: gtk-webkit2 on Linux). Neutralinojs implements a WebSocket connection for native operations and embeds a static web server to serve the web content. Also, it offers a built-in [JavaScript client library](https://github.com/neutralinojs/neutralino.js) for developers.
 
@@ -48,7 +48,7 @@ Ask questions on StackOverflow using tag [neutralinojs](https://stackoverflow.co
 
 ## Contributing
 
-Please check the [contribution guide](https://neutralino.js.org/docs/contributing/framework-developer-guide). We use GitHub Discussions and Discord for quick discussions. 
+Please check the [contribution guide](https://neutralino.js.org/docs/contributing/framework-developer-guide). We use GitHub Discussions and Discord for quick discussions.
   * [Join on Discord](https://discord.gg/cybpp4guTJ)
   * [Start a thread on Discussions](https://github.com/neutralinojs/neutralinojs/discussions)
 
@@ -78,8 +78,8 @@ If you like to support our work, you can donate to Neutralinojs via [Patreon](ht
 - Neutralinojs core: MIT. Copyright (c) 2021 Neutralinojs and contributors.
 - C++ websocket client/server library: BSD-3-Clause from [zaphoyd/websocketpp](https://github.com/zaphoyd/websocketpp). Copyright (c) 2014, Peter Thorson. All rights reserved.
 - JSON parser library: MIT from [nlohmann/json](https://github.com/nlohmann/json). Copyright (c) 2013-2022 Niels Lohmann.
-- Cross-platform webview library: MIT from [webview/webview](https://github.com/webview/webview). Copyright (c) 2017 Serge Zaitsev. 
-- Cross-platform tray library: MIT from [zserge/tray](https://github.com/zserge/tray). Copyright (c) 2017 Serge Zaitsev. 
+- Cross-platform webview library: MIT from [webview/webview](https://github.com/webview/webview). Copyright (c) 2017 Serge Zaitsev.
+- Cross-platform tray library: MIT from [zserge/tray](https://github.com/zserge/tray). Copyright (c) 2017 Serge Zaitsev.
 - Cross-platform GUI dialogs library: WTFPL from [samhocevar/portable-file-dialogs](https://github.com/samhocevar/portable-file-dialogs). Copyright (c) 2018—2020 Sam Hocevar
 - Base64 encoder/decoder library: MIT from [tobiaslocker/base64](https://github.com/tobiaslocker/base64). Copyright (c) 2019 Tobias Locker.
 - Cross-platform known platform directories API: MIT from [sago007/PlatformFolders](https://github.com/sago007/PlatformFolders). Copyright (c) 2015 Poul Sander.
@@ -89,7 +89,7 @@ If you like to support our work, you can donate to Neutralinojs via [Patreon](ht
 - Cross-platform C++ clipboard library: MIT from [dacap/clip](https://github.com/dacap/clip). Copyright (c) 2015-2021 David Capello
 - Cross-platform C++ system information library: CC0 1.0 Universal from [ThePhD/infoware](https://github.com/ThePhD/infoware). Written in 2016-2020 by nabijaczleweli and ThePhD
 - Cross-platform C++ filesystem watcher library: MIT from [SpartanJ/efsw](https://github.com/SpartanJ/efsw). Copyright (c) 2020 Martín Lucas Golini
-- Logo design credits: [IconsPng](https://www.iconspng.com/image/2688/atom-orange). Copyright free as mentioned in their website. 
+- Logo design credits: [IconsPng](https://www.iconspng.com/image/2688/atom-orange). Copyright free as mentioned in their website.
 
 [See the complete license file](LICENSE)
 

--- a/api/app/app.h
+++ b/api/app/app.h
@@ -22,6 +22,8 @@ json broadcast(const json &input);
 json readProcessInput(const json &input);
 json writeProcessOutput(const json &input);
 json writeProcessError(const json &input);
+json mount(const json &input);
+json unmount(const json &input);
 
 } // namespace controllers
 

--- a/errors.cpp
+++ b/errors.cpp
@@ -18,6 +18,9 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_ST_NOSTKEX: return "NE_ST_NOSTKEX";
         case errors::NE_ST_STKEYWE: return "NE_ST_STKEYWE";
         case errors::NE_ST_NOSTDIR: return "NE_ST_NOSTDIR";
+        // app
+        case errors::NE_AP_MPINUSE: return "NE_AP_MPINUSE";
+        case errors::NE_AP_NOMTPTH: return "NE_AP_NOMTPTH";
         // os
         case errors::NE_OS_UNLTOUP: return "NE_OS_UNLTOUP";
         case errors::NE_OS_INVNOTA: return "NE_OS_INVNOTA";
@@ -32,6 +35,7 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_FS_REMVERR: return "NE_FS_REMVERR";
         case errors::NE_FS_FILRDER: return "NE_FS_FILRDER";
         case errors::NE_FS_NOPATHE: return "NE_FS_NOPATHE";
+        case errors::NE_FS_NOTADIR: return "NE_FS_NOTADIR";
         case errors::NE_FS_COPYERR: return "NE_FS_COPYERR";
         case errors::NE_FS_MOVEERR: return "NE_FS_MOVEERR";
         case errors::NE_FS_FILOPER: return "NE_FS_FILOPER";
@@ -72,6 +76,9 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_ST_NOSTKEX: return "Unable to find storage key: %1";
         case errors::NE_ST_STKEYWE: return "Unable to write data to key: %1";
         case errors::NE_ST_NOSTDIR: return "Unable to read storage directory: %1";
+        // app
+        case errors::NE_AP_MPINUSE: return "Mount path is already in use: %1";
+        case errors::NE_AP_NOMTPTH: return "Cannot unmount a path that was not mounted: %1";
         // os
         case errors::NE_OS_UNLTOUP: return "Unable to update process id: %1";
         case errors::NE_OS_INVNOTA: return "Invalid notification style arguments: %1";
@@ -86,6 +93,7 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_FS_REMVERR: return "Cannot remove path: %1";
         case errors::NE_FS_FILRDER: return "Unable to open file: %1";
         case errors::NE_FS_NOPATHE: return "Unable to open path %1";
+        case errors::NE_FS_NOTADIR: return "Path %1 is not a directory";
         case errors::NE_FS_COPYERR: return "Cannot perform copy: %1";
         case errors::NE_FS_MOVEERR: return "Cannot perform move: %1";
         case errors::NE_FS_FILOPER: return "Unable to open file: %1";
@@ -106,7 +114,6 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_RS_UNBLDRE: return "Unable to load application resource file %1";
         case errors::NE_RS_APIRQRF: return "Resource API works only when the resource file is loaded";
         case errors::NE_RS_FILNOTF: return "The request file (%1) is not found in the resource bundle";
-        
         // server
         case errors::NE_SR_UNBSEND: return "Unable to send native message";
         case errors::NE_SR_UNBPARS: return "Unable to parse native call payload";

--- a/errors.h
+++ b/errors.h
@@ -18,6 +18,9 @@ enum StatusCode {
     NE_ST_NOSTKEX,
     NE_ST_STKEYWE,
     NE_ST_NOSTDIR,
+    // app
+    NE_AP_MPINUSE,
+    NE_AP_NOMTPTH,
     // os
     NE_OS_UNLTOUP,
     NE_OS_INVNOTA,
@@ -32,6 +35,7 @@ enum StatusCode {
     NE_FS_REMVERR,
     NE_FS_FILRDER,
     NE_FS_NOPATHE,
+    NE_FS_NOTADIR,
     NE_FS_COPYERR,
     NE_FS_MOVEERR,
     NE_FS_FILOPER,

--- a/server/router.h
+++ b/server/router.h
@@ -12,6 +12,10 @@ using json = nlohmann::json;
 
 namespace router {
 
+void mountPath(const string &path, const string &mountPoint);
+bool isMounted(const string &path);
+void unmountPath(const string &path);
+
 typedef json (*NativeMethod)(const json &);
 
 struct Response {

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -1,9 +1,10 @@
+const fs = require('fs/promises');
 const assert = require('assert');
 const runner = require('./runner');
 
 describe('app.spec: app namespace tests', () => {
     describe('app.exit', () => {
-            
+
         it('works without parameters', async () => {
             let exitCode = runner.run(`
                 setTimeout(() => {
@@ -21,7 +22,7 @@ describe('app.spec: app namespace tests', () => {
             `);
             assert.ok(typeof exitCode != undefined);
         });
-        
+
         it('throws an error for invalid exit codes', async () => {
             runner.run(`
                 try {
@@ -42,6 +43,75 @@ describe('app.spec: app namespace tests', () => {
                 }, 2000);
             `);
             assert.ok(exitCode != 0);
+        });
+    });
+
+    describe('app.mount', () => {
+        it('mounts and serves a directory successfully', async () => {
+            await fs.mkdir('./.tmp/test-mount', {
+                recursive: true
+            });
+            await fs.writeFile('./.tmp/test-mount/test.txt', 'Hello', {
+                encoding: 'utf8'
+            });
+            try {
+                runner.run(`
+                    const response = {};
+                    const targetPath = NL_CWD + '/.tmp/test-mount';
+
+                    const fetch1 = await fetch('/test/test.txt');
+                    response.fetch1 = fetch1.status;
+
+                    await Neutralino.app.mount('/test', targetPath);
+
+                    const fetch2 = await fetch('/test/test.txt');
+                    response.fetch2 = fetch2.status;
+
+                    await __close(JSON.stringify(response));
+                `);
+                const output = JSON.parse(runner.getOutput());
+                assert.ok(typeof output === 'object', 'Expected output is an object');
+                assert.ok(output.fetch1 === 404, 'Expected fetch1 to be 404');
+                assert.ok(output.fetch2 === 200, 'Expected fetch2 to be 200');
+            } finally {
+                await fs.rmdir('./.tmp/test-mount', {
+                    recursive: true
+                });
+            }
+        });
+        it('unmounts a directory successfully', async () => {
+            await fs.mkdir('./.tmp/test-mount', {
+                recursive: true
+            });
+            await fs.writeFile('./.tmp/test-mount/test.txt', 'Hello', {
+                encoding: 'utf8'
+            });
+            try {
+                runner.run(`
+                    const response = {};
+                    const targetPath = NL_CWD + '/.tmp/test-mount';
+
+                    await Neutralino.app.mount('/test', targetPath);
+
+                    const fetch1 = await fetch('/test/test.txt');
+                    response.fetch1 = fetch1.status;
+
+                    await Neutralino.app.unmount('/test');
+
+                    const fetch2 = await fetch('/test/test.txt');
+                    response.fetch2 = fetch2.status;
+
+                    await __close(JSON.stringify(response));
+                `);
+                const output = JSON.parse(runner.getOutput());
+                assert.ok(typeof output === 'object', 'Expected output is an object');
+                assert.ok(output.fetch1 === 200, 'Expected fetch1 to be 200');
+                assert.ok(output.fetch2 === 404, 'Expected fetch2 to be 404');
+            } finally {
+                await fs.rmdir('./.tmp/test-mount', {
+                    recursive: true
+                });
+            }
         });
     });
 

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -71,8 +71,8 @@ describe('app.spec: app namespace tests', () => {
                 `);
                 const output = JSON.parse(runner.getOutput());
                 assert.ok(typeof output === 'object', 'Expected output is an object');
-                assert.ok(output.fetch1 === 404, 'Expected fetch1 to be 404');
-                assert.ok(output.fetch2 === 200, 'Expected fetch2 to be 200');
+                assert.ok(output.fetch1 === 404, 'Expected a request to a file in a yet not mounted directory to fail');
+                assert.ok(output.fetch2 === 200, 'Expected a request to a file in a mounted directory to succeed');
             } finally {
                 await fs.rmdir('./.tmp/test-mount', {
                     recursive: true
@@ -105,8 +105,8 @@ describe('app.spec: app namespace tests', () => {
                 `);
                 const output = JSON.parse(runner.getOutput());
                 assert.ok(typeof output === 'object', 'Expected output is an object');
-                assert.ok(output.fetch1 === 200, 'Expected fetch1 to be 200');
-                assert.ok(output.fetch2 === 404, 'Expected fetch2 to be 404');
+                assert.ok(output.fetch1 === 200, 'Expected a file request to a mounted directory before unmounting it to succeed');
+                assert.ok(output.fetch2 === 404, 'Expected a file request to an unmounted directory to fail');
             } finally {
                 await fs.rmdir('./.tmp/test-mount', {
                     recursive: true


### PR DESCRIPTION
Closes #993
Provides a solution to #1291 use case but is not a solution for the `file://` protocol.

## Description
This PR adds new methods `Neutralino.app.mount` and `Neutralino.app.unmount` that allow to add and remove filesystem folders on local machine to be included in Neutralino's web server routing.

Calling `Neutralino.app.mount('/sausage', 'C:/Users/CoMiGo/Some Directory');` will make any requests to `/sausage/**` to read and serve files from that folder:

* fetching `/sausage` will try to load `C:/Users/CoMiGo/Some Directory/index.html`
* fetching `/sausage/hello.txt` will try to load `C:/Users/CoMiGo/Some Directory/hello.txt`
* fetching `/not-a-sausage/hello.txt` will try to load a file from the app's resources folder as usual.

Calling `Neutralino.app.unmount('/sausage')` will revert the changes to the router.

Several different mounts can be established at once, too.

This unlocks several use cases for app developers:

* Scoping a part of end user's filesystem as a subroute in an app to:
  * Simplify working with filesystem's paths (which is useful for anything that works with user projects);
  * Bypass issues with `file://` protocol that is currently unusable and would have problems with WebAudio and other issues anyways;
  * Remove the need to use filesystem.readBinaryFile + Blobs to use local images/audio/video in webpages;
* Local testing for web projects built by an app: for example, games and websites in a game maker / website constructor. Can be made with an iframe or by calling `app.mount`, then navigating to it with `location.href = '/sausage';`.
* Proxying the whole filesystem for image viewers and other file-manager-like apps. 

## Changes proposed

* Add app.mount and app.unmount methods
* Add new error codes relevant to the methods
* Add tests for them
* Remove trailing whitespace in a couple of places

## How to test it

I added a couple tests to `app.spec.js`. Should be doable with `npm run test` in the spec folder

## Next steps

* Send a PR to the client library (done, https://github.com/neutralinojs/neutralino.js/pull/142)
* Send a PR for the docs (done, https://github.com/neutralinojs/neutralinojs.github.io/pull/367)

## Deploy notes

⚠️ This is my first real C++ work **ever**, ignoring the long forgotten university curriculum. Please check the code carefully as I may or may not have done dumb shit. And if not Pieces App and Claude Sonnet, I wouldn't write it in one evening. _But,_ it works, I tested it with different paths and made sure they are normalized.

You are also free to move stuff around and/or rename the methods.