### PR TITLE
:zap: Host pages from 127.0.0.1 instead of localhost

### DIFF
--- a/server/neuserver.cpp
+++ b/server/neuserver.cpp
@@ -133,7 +133,7 @@ string init() {
         settings::setPort(port);
     }
 
-    string navigationUrl = "http://localhost:" + std::to_string(port);
+    string navigationUrl = "http://127.0.0.1:" + std::to_string(port);
     json jUrl = settings::getOptionForCurrentMode("url");
 
     if(!jUrl.is_null()) {


### PR DESCRIPTION
Closes #957
Closes #1217

## Description
Ssssoooo... Windows is a "miracle".
When serving files from `localhost`, any [requests to `localhost` will go through DNS resolve system](https://stackoverflow.com/questions/2386299/running-sites-on-localhost-is-extremely-slow) and will have long Initial Connection time. In my case this time takes 300ms for **each** request on a pretty powerful laptop.

The problem became evident when migrating to my Neutralino.app.mount method when working with local files.

Loading a project on localhost:

![localhost](https://github.com/user-attachments/assets/57f492d9-fabf-4799-804e-5a2d52552fae)

See those yellow lines? Each is 300ms+ long and is resolving `localhost` (the Initial Connection stat in DevTools' Network tab.)

Loading the same project on 127.0.0.1:

![127001](https://github.com/user-attachments/assets/58ce0bcc-e8a9-4487-bf38-6c8e7b440e46)

Changing the hostname also made my app load noticeably faster.

## Changes proposed

* Neutralino.js will now open applications on `http://127.0.0.1:PORT` instead of `http://localhost:PORT`

## How to test it

* Apps work even despite having a client patched to connect through websockets with 127.0.0.1. Speed change should be measured manually.

## Next steps

* (Done) Add a PR to neutralino.js client library as it currently opens its websockets connection on `localhost`. This will make native API initialization faster on Windows. https://github.com/neutralinojs/neutralino.js/pull/143

## Deploy notes

⚠️ This may break some existing projects if they defined a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in their apps. (For example, to load and work with blobs.)

In my engine, I had to expand it a bit:

```diff
<meta
    http-equiv="Content-Security-Policy"
    content="
        connect-src
-            https: file: ipc: socket: ws://localhost:* http://localhost:* blob:;
+            https: file: ipc: socket: ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:* blob:;
        script-src
-            https: socket: http://localhost:* 'unsafe-eval' 'unsafe-inline' blob:;
+            https: socket: http://localhost:* http://127.0.0.1:* 'unsafe-eval' 'unsafe-inline' blob:;
        img-src
-            https: data: file: blob: http://localhost:*">
+            https: data: file: blob: http://localhost:* http://127.0.0.1:*;">
```

But default Neutralino project runs just fine.