### PR TITLE
add setVDocRoot function

### DIFF
--- a/api/server/server.cpp
+++ b/api/server/server.cpp
@@ -55,5 +55,23 @@ json getMounts(const json &input) {
     return output;
 }
 
+//  set a Virtual Document Root
+json setVDocRoot(const json &input) {
+    json output;
+    string path = input["path"].get<string>();
+    errors::StatusCode mountStatus = router::setVDocRoot(path);
+    
+    if(mountStatus != errors::NE_ST_OK) {
+        output["error"] = errors::makeErrorPayload(mountStatus, path);
+    }
+    else {
+        output["message"] = "vdocroot mounts to " + path ;
+        output["success"] = true;
+    }
+
+    return output;
+}
+
+
 } // namespace controllers
 } // namespace server

--- a/api/server/server.h
+++ b/api/server/server.h
@@ -15,6 +15,9 @@ json mount(const json &input);
 json unmount(const json &input);
 json getMounts(const json &input);
 
+// set a Virtual Document Root
+json setVDocRoot(const json &input);
+
 
 } // namespace controllers
 

--- a/server/router.h
+++ b/server/router.h
@@ -36,6 +36,8 @@ errors::StatusCode mountPath(string &path, string &target);
 bool isMounted(const string &path);
 bool unmountPath(string &path);
 map<string, string> getMounts();
+// set a Virtual Document Root
+errors::StatusCode setVDocRoot(string &path);
 
 } // namespace router
 


### PR DESCRIPTION
## Description
Implements a virtual document root for local folders. When building an application to access local files, system functions can be used to read and display file content. However, if a file (such as an HTML document) references other local files (e.g., images in the same folder), these references typically fail to resolve (see #1291).

## Changes proposed
Adds a `setVDocRoot` function to designate a local folder as the virtual document root for resources.

## How to test it
Before opening a local HTML file containing referenced images, use `setVDocRoot` to set the virtual document root to the folder containing the HTML file and images. Verify that the images are displayed correctly.

## Deploy notes
This change introduces a new function, `setVDocRoot`, which may require adjustments to existing build processes or deployment scripts if they rely on specific file paths. Ensure that the correct path is passed to setVDocRoot during application initialization. Consider adding documentation or examples demonstrating its usage.

You need update your neutralino.js too. https://github.com/neutralinojs/neutralino.js/pull/147

## Usage
```js
      Neutralino.server
         .setVDocRoot(path)
         .then((resault) => {
            console.log("setVDocRoot:", resault)
        })
        .catch((error) => {
          console.error("setVDocRoot error:", error);
        });
```