### PR TITLE
Added HTML Clipboard Support

### DIFF
--- a/api/clipboard/clipboard.cpp
+++ b/api/clipboard/clipboard.cpp
@@ -119,6 +119,30 @@ json writeText(const json &input) {
     return output;
 }
 
+json readHTML(const json &input) {
+    json output;
+    string clipHTML = "";
+    if(clip::has(clip::html_format())) {
+        clip::get_html(clipHTML);
+    }
+    output["returnValue"] = clipHTML;
+    output["success"] = true;
+    return output;
+}
+
+json writeHTML(const json &input) {
+    json output;
+    if(!helpers::hasRequiredFields(input, {"data"})) {
+        output["error"] = errors::makeMissingArgErrorPayload();
+        return output;
+    }
+    string htmlData = input["data"].get<string>();
+    clip::set_html(htmlData);
+
+    output["success"] = true;
+    return output;
+}
+
 json clear(const json &input) {
     json output;
     clip::clear();

--- a/api/clipboard/clipboard.h
+++ b/api/clipboard/clipboard.h
@@ -17,6 +17,8 @@ json readText(const json &input);
 json readImage(const json &input);
 json writeText(const json &input);
 json writeImage(const json &input);
+json writeHTML(const json &input);
+json readHTML(const json &input);
 json clear(const json &input);
 
 } // namespace controllers

--- a/lib/clip/clip.h
+++ b/lib/clip/clip.h
@@ -71,6 +71,13 @@ namespace clip {
   // When the clipboard has UTF8 text.
   format text_format();
 
+  format html_format();
+
+  // High-level API to put/get HTML in/from the clipboard. These
+  // functions returns false in case of error.
+  bool set_html(const std::string& value);
+  bool get_html(std::string& value);
+
 #if CLIP_ENABLE_IMAGE
   // When the clipboard has an image.
   format image_format();

--- a/lib/clip/clip_win.cpp
+++ b/lib/clip/clip_win.cpp
@@ -277,10 +277,8 @@ bool lock::impl::set_data(format f, const char* buf, size_t len) {
     }
   }
   else if (f == html_format()) {
-    // Get the registered HTML format
     UINT CF_HTML = html_format();
 
-    // Construct the HTML header with placeholders
     std::string headerTemplate = 
       "Version:0.9\r\n"
       "StartHTML:00000000\r\n"
@@ -295,18 +293,16 @@ bool lock::impl::set_data(format f, const char* buf, size_t len) {
       "</body>\r\n"
       "</html>";
 
-    // Combine header, content, and footer
     std::string fullHtmlContent = headerTemplate + 
       std::string(buf, len) + 
       footerTemplate;
 
-    // Calculate offsets
     size_t startHtmlOffset = headerTemplate.find("StartHTML:") + 10;
     size_t endHtmlOffset = headerTemplate.find("EndHTML:") + 8;
     size_t startFragOffset = headerTemplate.find("StartFragment:") + 14;
     size_t endFragOffset = headerTemplate.find("EndFragment:") + 12;
 
-    // Calculate and replace offsets
+
     char offsetBuffer[9];
     sprintf(offsetBuffer, "%08zu", headerTemplate.length());
     fullHtmlContent.replace(startHtmlOffset, 8, offsetBuffer);
@@ -320,7 +316,6 @@ bool lock::impl::set_data(format f, const char* buf, size_t len) {
     sprintf(offsetBuffer, "%08zu", fullHtmlContent.length() - footerTemplate.length());
     fullHtmlContent.replace(endFragOffset, 8, offsetBuffer);
 
-    // Allocate global memory for the HTML content
     Hglobal hglobal(fullHtmlContent.size() + 1);
     if (hglobal) {
       auto dst = static_cast<char*>(GlobalLock(hglobal));

--- a/lib/clip/clip_win.cpp
+++ b/lib/clip/clip_win.cpp
@@ -276,6 +276,65 @@ bool lock::impl::set_data(format f, const char* buf, size_t len) {
       }
     }
   }
+  else if (f == html_format()) {
+    // Get the registered HTML format
+    UINT CF_HTML = html_format();
+
+    // Construct the HTML header with placeholders
+    std::string headerTemplate = 
+      "Version:0.9\r\n"
+      "StartHTML:00000000\r\n"
+      "EndHTML:00000000\r\n"
+      "StartFragment:00000000\r\n"
+      "EndFragment:00000000\r\n"
+      "<html><body>\r\n"
+      "<!--StartFragment -->\r\n";
+
+    std::string footerTemplate = 
+      "\r\n<!--EndFragment-->\r\n"
+      "</body>\r\n"
+      "</html>";
+
+    // Combine header, content, and footer
+    std::string fullHtmlContent = headerTemplate + 
+      std::string(buf, len) + 
+      footerTemplate;
+
+    // Calculate offsets
+    size_t startHtmlOffset = headerTemplate.find("StartHTML:") + 10;
+    size_t endHtmlOffset = headerTemplate.find("EndHTML:") + 8;
+    size_t startFragOffset = headerTemplate.find("StartFragment:") + 14;
+    size_t endFragOffset = headerTemplate.find("EndFragment:") + 12;
+
+    // Calculate and replace offsets
+    char offsetBuffer[9];
+    sprintf(offsetBuffer, "%08zu", headerTemplate.length());
+    fullHtmlContent.replace(startHtmlOffset, 8, offsetBuffer);
+
+    sprintf(offsetBuffer, "%08zu", fullHtmlContent.length());
+    fullHtmlContent.replace(endHtmlOffset, 8, offsetBuffer);
+
+    sprintf(offsetBuffer, "%08zu", headerTemplate.length() + headerTemplate.find("<!--StartFragment -->") - headerTemplate.find("<html>"));
+    fullHtmlContent.replace(startFragOffset, 8, offsetBuffer);
+
+    sprintf(offsetBuffer, "%08zu", fullHtmlContent.length() - footerTemplate.length());
+    fullHtmlContent.replace(endFragOffset, 8, offsetBuffer);
+
+    // Allocate global memory for the HTML content
+    Hglobal hglobal(fullHtmlContent.size() + 1);
+    if (hglobal) {
+      auto dst = static_cast<char*>(GlobalLock(hglobal));
+      if (dst) {
+        memcpy(dst, fullHtmlContent.c_str(), fullHtmlContent.size());
+        dst[fullHtmlContent.size()] = '\0';  // Null-terminate
+        GlobalUnlock(hglobal);
+        
+        result = (SetClipboardData(CF_HTML, hglobal) ? true : false);
+        if (result)
+          hglobal.release();
+      }
+    }
+  }
   else {
     Hglobal hglobal(len+sizeof(CustomSizeT));
     if (hglobal) {
@@ -335,6 +394,20 @@ bool lock::impl::get_data(format f, char* buf, size_t len) const {
       }
     }
   }
+  else if (f == html_format()) {
+    if (IsClipboardFormatAvailable(html_format())) {
+      HGLOBAL hglobal = GetClipboardData(html_format());
+      if (hglobal) {
+        LPSTR lpstr = (LPSTR)GlobalLock(hglobal);
+        if (lpstr) {
+          // TODO check length
+          memcpy(buf, lpstr, len);
+          result = true;
+          GlobalUnlock(hglobal);
+        }
+      }
+    }
+  }
   else {
     if (IsClipboardFormatAvailable(f)) {
       HGLOBAL hglobal = GetClipboardData(f);
@@ -383,6 +456,18 @@ size_t lock::impl::get_data_length(format f) const {
     }
     else if (IsClipboardFormatAvailable(CF_TEXT)) {
       HGLOBAL hglobal = GetClipboardData(CF_TEXT);
+      if (hglobal) {
+        LPSTR lpstr = (LPSTR)GlobalLock(hglobal);
+        if (lpstr) {
+          len = strlen(lpstr) + 1;
+          GlobalUnlock(hglobal);
+        }
+      }
+    }
+  }
+  else if(f == html_format()) {
+    if (IsClipboardFormatAvailable(html_format())) {
+      HGLOBAL hglobal = GetClipboardData(html_format());
       if (hglobal) {
         LPSTR lpstr = (LPSTR)GlobalLock(hglobal);
         if (lpstr) {

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -135,6 +135,8 @@ map<string, router::NativeMethod> methodMap = {
     {"clipboard.readText", clipboard::controllers::readText},
     {"clipboard.readImage", clipboard::controllers::readImage},
     {"clipboard.writeText", clipboard::controllers::writeText},
+    {"clipboard.writeHTML", clipboard::controllers::writeHTML},
+    {"clipboard.readHTML", clipboard::controllers::readHTML},
     {"clipboard.writeImage", clipboard::controllers::writeImage},
     {"clipboard.clear", clipboard::controllers::clear},
     // Neutralino.resources


### PR DESCRIPTION
Fixes: #1361 


## Description
Added HTML clipboard support to Neutralinojs, enabling rich text and formatted content handling across platforms.

## Changes proposed
- Implemented HTML clipboard API methods: writeHTML() and readHTML()
- Used Microsoft HTML clipboard format for Windows (Reference: [Microsoft HTML Clipboard Format](https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/cpp/language-compilers/add-html-code-clipboard))
- Linux support via native text/html format
- Added comprehensive test suite for HTML clipboard operations

## Platform Compatibility
- Windows: Microsoft HTML clipboard format implemented
- Linux: Native text/html format support
- macOS: Native public.html format expected to work, but requires verification as I don't have macOS environment to test it

## How to test it
- Verify HTML clipboard operations by creating a simple test app & perform different operation in rich text editor
- Test cross-platform compatibility (Windows, Linux)

## Next steps
- Verify macOS compatibility for this implementation

## Demo
I have added a Demo showcasing the implementation in Linux

[Screencast from 26-01-25 07:36:58 PM IST.webm](https://github.com/user-attachments/assets/039f929b-36de-4ddc-a1d9-dcdd7c03ee6b)

