### PR TITLE
Fix: Windows 11 notification support by implementing proper window ha…

### DIFF
--- a/lib/filedialogs/portable-file-dialogs.h
+++ b/lib/filedialogs/portable-file-dialogs.h
@@ -1345,21 +1345,40 @@ inline notify::notify(std::string const &title,
     // until the program has finished running.
     struct notify_icon_data : public NOTIFYICONDATAW
     {
-        ~notify_icon_data() { Shell_NotifyIconW(NIM_DELETE, this); }
+        ~notify_icon_data() { 
+            Shell_NotifyIconW(NIM_DELETE, this); 
+            if (this->hWnd)
+                DestroyWindow(this->hWnd);
+        }
     };
 
     static std::shared_ptr<notify_icon_data> nid;
 
+    // Create a temporary window to own the notification
+    WNDCLASSW wc = {0};
+    wc.lpfnWndProc = DefWindowProcW;
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = L"PfdNotifyClass";
+    RegisterClassW(&wc);
+    
+    HWND hwnd = CreateWindowW(L"PfdNotifyClass", L"PfdNotifyWindow",
+                             0, 0, 0, 0, 0, nullptr, nullptr,
+                             GetModuleHandle(nullptr), nullptr);
+
+    if (!hwnd) {
+        // Fallback to null window handle if creation fails
+        hwnd = nullptr;
+    }
     // Release the previous notification icon, if any, and allocate a new
     // one. Note that std::make_shared() does value initialization, so there
     // is no need to memset the structure.
     nid = nullptr;
     nid = std::make_shared<notify_icon_data>();
 
-    // For XP support
-    nid->cbSize = NOTIFYICONDATAW_V2_SIZE;
-    nid->hWnd = nullptr;
-    nid->uID = 0;
+    // Use full size for modern Windows
+    nid->cbSize = sizeof(NOTIFYICONDATAW);
+    nid->hWnd = hwnd;
+    nid->uID = 1;
 
     // Flag Description:
     // - NIF_ICON    The hIcon member is valid.
@@ -1368,7 +1387,9 @@ inline notify::notify(std::string const &title,
     // - NIF_STATE   The dwState and dwStateMask members are valid.
     // - NIF_INFO    Use a balloon ToolTip instead of a standard ToolTip. The szInfo, uTimeout, szInfoTitle, and dwInfoFlags members are valid.
     // - NIF_GUID    Reserved.
-    nid->uFlags = NIF_MESSAGE | NIF_ICON | NIF_INFO;
+    // NIF_SHOWTIP is required for Windows 8+ balloon notifications
+    nid->uFlags = NIF_MESSAGE | NIF_ICON | NIF_INFO | NIF_SHOWTIP;
+    nid->uVersion = NOTIFYICON_VERSION_4;  // Version 4 is required for modern Windows notification support
 
     // Flag Description
     // - NIIF_ERROR     An error icon.
@@ -1379,27 +1400,29 @@ inline notify::notify(std::string const &title,
     // - NIIF_NOSOUND   Version 6.0. Do not play the associated sound. Applies only to balloon ToolTips
     switch (_icon)
     {
-        case icon::warning: nid->dwInfoFlags = NIIF_WARNING; break;
-        case icon::error: nid->dwInfoFlags = NIIF_ERROR; break;
-        /* case icon::info: */ default: nid->dwInfoFlags = NIIF_INFO; break;
+        case icon::warning: 
+            nid->dwInfoFlags = NIIF_WARNING | NIIF_LARGE_ICON; 
+            nid->hIcon = LoadIcon(nullptr, IDI_WARNING);
+            break;
+        case icon::error: 
+            nid->dwInfoFlags = NIIF_ERROR | NIIF_LARGE_ICON; 
+            nid->hIcon = LoadIcon(nullptr, IDI_ERROR);
+            break;
+        default: 
+            nid->dwInfoFlags = NIIF_INFO | NIIF_LARGE_ICON; 
+            nid->hIcon = LoadIcon(nullptr, IDI_INFORMATION);
+            break;
     }
-
-    ENUMRESNAMEPROC icon_enum_callback = [](HMODULE, LPCTSTR, LPTSTR lpName, LONG_PTR lParam) -> BOOL
-    {
-        ((NOTIFYICONDATAW *)lParam)->hIcon = ::LoadIcon(GetModuleHandle(nullptr), lpName);
-        return false;
-    };
-
-    nid->hIcon = ::LoadIcon(nullptr, IDI_APPLICATION);
-    ::EnumResourceNames(nullptr, RT_GROUP_ICON, icon_enum_callback, (LONG_PTR)nid.get());
-
-    nid->uTimeout = 5000;
 
     StringCchCopyW(nid->szInfoTitle, ARRAYSIZE(nid->szInfoTitle), internal::str2wstr(title).c_str());
     StringCchCopyW(nid->szInfo, ARRAYSIZE(nid->szInfo), internal::str2wstr(message).c_str());
 
-    // Display the new icon
-    Shell_NotifyIconW(NIM_ADD, nid.get());
+    if (!Shell_NotifyIconW(NIM_ADD, nid.get()))
+    {
+        Shell_NotifyIconW(NIM_MODIFY, nid.get());
+    }
+
+    Shell_NotifyIconW(NIM_SETVERSION, nid.get());
 #else
     auto command = desktop_helper();
 


### PR DESCRIPTION
Fixes: #1157 

## Description 
The main issue was that notifications weren't working on Windows 11 due to outdated API usage. So Instead of using something like WinToast, I improved pfd integration.

## Changes proposed
- Created a temporary window context for Notifications
- Updated to modern notification API (Version 4) 

## Testing:
- Tested on Windows 11 
- Run await Neutralino.os.showNotification()
- Verified notifications appear with correct icons 
- All the tests are passing successfully after running `npm run test os` inside spec folder 

