### PR TITLE
Allow to specify environment variables for os.spawnProcess

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -710,5 +710,27 @@ json getPath(const json &input) {
     }
     return output;
 }
+string setEnvVar(const std::string& key, const std::string& value) {
+    json output;
+    if(!getEnv(value).empty()){
+        output["error"] = errors::makeErrorPayload(errors::NE_OS_ENVEXISTS);
+    }else if(key.empty() || value.empty()){
+        output["error"] = errors::makeMissingArgErrorPayload();
+    }
+
+#ifdef _WIN32
+    if(_putenv_s(key.c_str(), value.c_str()) != 0){
+        output["error"] = errors::makeErrorPayload(errors::NE_OS_CNCENV);
+    }
+#else
+    if(setenv(key.c_str(), value.c_str(), 1) != 0){
+        output["error"] = errors::makeErrorPayload(errors::NE_OS_CNCENV);
+    }
+#endif
+    output["success"] = true;
+    output["message"] = "Environment variable set successfully";
+    return output;
+}
+
 } // namespace controllers
 } // namespace os

--- a/api/os/os.h
+++ b/api/os/os.h
@@ -31,9 +31,7 @@ pair<int, int> spawnProcess(string command, const string &cwd = "");
 bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt);
 string getPath(const string &name);
 string getEnv(const string &key);
-
-string setEnvVar(const string& key, const string& value);
-string spawnProcessWithEnv(const string& command, const std::map<std::string, std::string>& env, const string& cwd);
+pair<int, int> spawnProcessWithEnv(const string& command, const std::map<std::string, std::string>& env, const string& cwd);
 
 namespace controllers {
 
@@ -51,8 +49,6 @@ json showMessageBox(const json &input);
 json setTray(const json &input);
 json open(const json &input);
 json getPath(const json &input);
-
-json setEnvVar(const json& input);
 json spawnProcessWithEnv(const json& input);
 
 } // namespace controllers

--- a/api/os/os.h
+++ b/api/os/os.h
@@ -32,6 +32,9 @@ bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt);
 string getPath(const string &name);
 string getEnv(const string &key);
 
+string setEnvVar(const string& key, const string& value);
+string spawnProcessWithEnv(const string& command, const std::map<std::string, std::string>& env, const string& cwd);
+
 namespace controllers {
 
 json execCommand(const json &input);
@@ -48,6 +51,9 @@ json showMessageBox(const json &input);
 json setTray(const json &input);
 json open(const json &input);
 json getPath(const json &input);
+
+json setEnvVar(const json& input);
+json spawnProcessWithEnv(const json& input);
 
 } // namespace controllers
 

--- a/errors.cpp
+++ b/errors.cpp
@@ -82,6 +82,8 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_OS_INVMSGA: return "Invalid message box style arguments: %1";
         case errors::NE_OS_TRAYIER: return "Unable to initialize the tray menu";
         case errors::NE_OS_INVKNPT: return "Invalid platform path name: %1";
+        case errors::NE_OS_ENVEXISTS: return "Environment variable already exists";
+        case errors::NE_OS_CNCENV: return "Could not create environment variable";
         // extensions
         case errors::NE_EX_EXTNOTC: return "%1 is not connected yet";
         // filesystem
@@ -140,7 +142,6 @@ json makeErrorPayload(const errors::StatusCode code, const string &param) {
     error["message"] = __getStatusCodeDesc(code, param);
     return error;
 }
-
 string makeErrorMsg(const errors::StatusCode code, const string &param) {
     return __getStatusCodeString(code) + ": " + __getStatusCodeDesc(code, param);
 }

--- a/errors.h
+++ b/errors.h
@@ -24,6 +24,8 @@ enum StatusCode {
     NE_OS_INVMSGA,
     NE_OS_TRAYIER,
     NE_OS_INVKNPT,
+    NE_OS_ENVEXISTS,
+    NE_OS_CNCENV,
     // extensions
     NE_EX_EXTNOTC,
     // filesystem

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -120,8 +120,7 @@ map<string, router::NativeMethod> methodMap = {
     {"os.setTray", os::controllers::setTray},
     {"os.open", os::controllers::open},
     {"os.getPath", os::controllers::getPath},
-    {"os.setEnvVar", os::controllers::setEnvVar}
-    {"os.spawnProcessWithEnv", os::controller::spawnProcessWithEnv},
+    {"os.spawnProcessWithEnv", os::controllers::spawnProcessWithEnv},
     // Neutralino.storage
     {"storage.setData", storage::controllers::setData},
     {"storage.getData", storage::controllers::getData},

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -120,6 +120,8 @@ map<string, router::NativeMethod> methodMap = {
     {"os.setTray", os::controllers::setTray},
     {"os.open", os::controllers::open},
     {"os.getPath", os::controllers::getPath},
+    {"os.setEnvVar", os::controllers::setEnvVar}
+    {"os.spawnProcessWithEnv", os::controller::spawnProcessWithEnv},
     // Neutralino.storage
     {"storage.setData", storage::controllers::setData},
     {"storage.getData", storage::controllers::getData},


### PR DESCRIPTION
Addressing https://github.com/neutralinojs/neutralinojs/issues/1373

## Description
This PR adds a function ``spawnProcessWithEnv`` to spawn a process with a custom set of environment variables, the process will only be able to use those specified environment variables only.

## Changes proposed
- ``spawnProcessWithEnv`` to spawn a process with a list of custom environment variables to use for that process  
- Added proper error handling.
- Registered functions in the ``routers.cpp``


## Next steps
- Take input from the maintainer
- Improve the function
- Make further required changes.
