### PR TITLE
Implement environment variable support for spawnProcess

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -150,11 +150,7 @@ pair<int, int> spawnProcess(string command, const os::SpawnProcessOptions &optio
 
     if (!options.envs.empty()) {
         for (const auto& [key, value] : options.envs) {
-            #if defined(_WIN32)
-            processEnv[helpers::str2wstr(key)] = helpers::str2wstr(value);
-            #else
-            processEnv[key] = value;
-            #endif
+            processEnv[CONVSTR(key)] = CONVSTR(value);
         }
     }
 

--- a/api/os/os.h
+++ b/api/os/os.h
@@ -23,11 +23,16 @@ struct SpawnedProcessEvent {
     string stdIn = "";
 };
 
+struct SpawnProcessOptions {
+    string cwd = "";
+    map<string, string> envs;
+};
+
 bool isTrayInitialized();
 void cleanupTray();
 void open(const string &url);
 os::CommandResult execCommand(string command, const string &input = "", bool background = false, const string &cwd = "");
-pair<int, int> spawnProcess(string command, const string &cwd = "", const map<string, string> &env = {});
+pair<int, int> spawnProcess(string command, const os::SpawnProcessOptions &options = SpawnProcessOptions());
 bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt);
 string getPath(const string &name);
 string getEnv(const string &key);

--- a/api/os/os.h
+++ b/api/os/os.h
@@ -27,7 +27,7 @@ bool isTrayInitialized();
 void cleanupTray();
 void open(const string &url);
 os::CommandResult execCommand(string command, const string &input = "", bool background = false, const string &cwd = "");
-pair<int, int> spawnProcess(string command, const string &cwd = "");
+pair<int, int> spawnProcess(string command, const string &cwd = "", const map<string, string> &env = {});
 bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt);
 string getPath(const string &name);
 string getEnv(const string &key);


### PR DESCRIPTION
Related issue: #1373 

### Description
- This PR adds support for passing custom environment variables and working directories, which wasn't possible with the current `os.spawnProcess` API.

## Changes proposed
- Added `SpawnProcessOptions` struct supporting:
  - `cwd`: Working directory specification
  - `envs`: Custom environment variables
- App developers can simply get the parent process's environment variables using os.getEnvs() if they need:
   `Neutralino.os.spawnProcess('my-command', {envs: {...await Neutralino.os.getEnvs(), 'VAR1', '1', ...}});`
 
**Note:**  This implementation matches Node.js's child_process.exec behavior.