### PR TITLE
Added error hadling for insufficient permissions crash when creating /.tmp directory.

### DIFF
--- a/auth/authbasic.cpp
+++ b/auth/authbasic.cpp
@@ -37,7 +37,12 @@ void init() {
 
 void exportAuthInfo() {
     string tempDirPath = settings::joinAppDataPath("/.tmp");
-    filesystem::create_directories(CONVSTR(tempDirPath));
+    try {
+        filesystem::create_directories(CONVSTR(tempDirPath));
+    } catch (const std::filesystem::filesystem_error& e) {
+        debug::log(debug::LogTypeError, "Failed to create ./tmp directory. Make sure you have sufficient permissions.");
+        debug::log(debug::LogTypeError,std::string(e.what()));
+    }
     string tempAuthInfoPath = settings::joinAppDataPath("/.tmp/auth_info.json");
     fs::FileWriterOptions fileWriterOptions = {
         tempAuthInfoPath,

--- a/auth/authbasic.cpp
+++ b/auth/authbasic.cpp
@@ -39,9 +39,10 @@ void exportAuthInfo() {
     string tempDirPath = settings::joinAppDataPath("/.tmp");
     try {
         filesystem::create_directories(CONVSTR(tempDirPath));
-    } catch (const std::filesystem::filesystem_error& e) {
-        debug::log(debug::LogTypeError, "Failed to create ./tmp directory. Make sure you have sufficient permissions.");
-        debug::log(debug::LogTypeError,std::string(e.what()));
+    } 
+    catch (const filesystem::filesystem_error& e) {
+        debug::log(debug::LogTypeError, "Failed to create " + tempDirPath);
+        return;
     }
     string tempAuthInfoPath = settings::joinAppDataPath("/.tmp/auth_info.json");
     fs::FileWriterOptions fileWriterOptions = {


### PR DESCRIPTION
## Description
As mentioned in https://github.com/neutralinojs/neutralinojs/issues/1292 neutralino app crashes when the folder does not have write permissions. 

The issue most probably arises from here:
https://github.com/neutralinojs/neutralinojs/blob/4f8c45e3640f8b9ae39b51a862899689a34256e3/auth/authbasic.cpp#L40

There is no error handling mechanism when calling ``filesystem::create_directory`` function which most likely causes the neutralino app to crash. If the exception is handled then possibly the app can be saved from crashing, and the debug message is printed on the console.

## Changes proposed
- Added error handling to ``filesystem::create_directory`` function call.


## How to test it
Needs testing on windows, i will be testing this on windows and try to simulate the same environment as mentioned in https://github.com/neutralinojs/neutralinojs/issues/1292  

## Next steps
We need to inspect more possible areas in code which can cause this error to occur, a few that i found are as follows:
- https://github.com/neutralinojs/neutralinojs/commit/5dc121762f8e27315a6ec8fc1dd54d8c84199cd9 (fixed)
- https://github.com/neutralinojs/neutralinojs/blob/4f8c45e3640f8b9ae39b51a862899689a34256e3/api/window/window.cpp#L231
- https://github.com/neutralinojs/neutralinojs/blob/4f8c45e3640f8b9ae39b51a862899689a34256e3/api/storage/storage.cpp#L87
