### PR TITLE
Implemented filesystem.access, filesystem.chmod, and filesystem.chown for Neutralino.filesystem API

### DIFF
--- a/api/fs/fs.h
+++ b/api/fs/fs.h
@@ -56,6 +56,18 @@ struct DirReaderResult {
     vector<DirReaderEntry> entries;
 };
 
+struct AccessResult {
+    errors::StatusCode status = errors::NE_ST_OK;
+};
+
+struct ChmodResult {
+    errors::StatusCode status = errors::NE_ST_OK;
+};
+
+struct ChownResult {
+    errors::StatusCode status = errors::NE_ST_OK;
+};
+
 fs::FileReaderResult readFile(const string &filename, const fs::FileReaderOptions &fileReaderOptions = {});
 bool writeFile(const fs::FileWriterOptions &fileWriterOptions);
 string getDirectoryName(const string &filename);
@@ -90,6 +102,9 @@ json getWatchers(const json &input);
 json getAbsolutePath(const json &input);
 json getRelativePath(const json &input);
 json getPathParts(const json &input);
+json access(const json &input);
+json chmod(const json &input);
+json chown(const json &input);
 
 } // namespace controllers
 

--- a/errors.cpp
+++ b/errors.cpp
@@ -40,6 +40,12 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_FS_UNLTFOP: return "NE_FS_UNLTFOP";
         case errors::NE_FS_UNLCWAT: return "NE_FS_UNLCWAT";
         case errors::NE_FS_NOWATID: return "NE_FS_NOWATID";
+        case errors::NE_FS_UNSUPPORTED: return "NE_FS_UNSUPPORTED";
+        case errors::NE_FS_ACCESSDENIED: return "NE_FS_ACCESSDENIED";
+        case errors::NE_FS_CHMODERR: return "NE_FS_CHMODERR";
+        case errors::NE_FS_INVALIDMODE: return "NE_FS_INVALIDMODE";
+        case errors:: NE_FS_INVALIDUIDGID: return "NE_FS_INVALIDUIDGID";
+        case errors:: NE_FS_CHOWNERR: return "NE_FS_CHOWNERR";
         // window
         case errors::NE_WI_UNBSWSR: return "NE_WI_UNBSWSR";
         // router
@@ -99,6 +105,12 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_FS_UNLTFOP: return "Unable to find opened file id: %1";
         case errors::NE_FS_UNLCWAT: return "Unable to create watcher for path: %1";
         case errors::NE_FS_NOWATID: return "Unable to find watcher: %1";
+        case errors::NE_FS_UNSUPPORTED: return "Unsupported operation for windows: %1";
+        case errors::NE_FS_ACCESSDENIED: return "Access denied for path: %1";
+        case errors::NE_FS_CHMODERR: return "Unable to change mode for path: %1";
+        case errors::NE_FS_INVALIDMODE: return "Invalid mode: %1";
+        case errors::NE_FS_INVALIDUIDGID: return "Invalid uid/gid values: %1";
+        case errors::NE_FS_CHOWNERR: return "Failed to change ownership for path: %1";
         // window
         case errors::NE_WI_UNBSWSR: return "Unable to save window screenshot to %1";
         // router

--- a/errors.h
+++ b/errors.h
@@ -40,6 +40,12 @@ enum StatusCode {
     NE_FS_UNLTFOP,
     NE_FS_UNLCWAT,
     NE_FS_NOWATID,
+    NE_FS_UNSUPPORTED,
+    NE_FS_ACCESSDENIED,
+    NE_FS_CHMODERR,
+    NE_FS_INVALIDMODE,
+    NE_FS_INVALIDUIDGID,
+    NE_FS_CHOWNERR,
     // window
     NE_WI_UNBSWSR,
     // router

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -105,6 +105,9 @@ map<string, router::NativeMethod> methodMap = {
     {"filesystem.getAbsolutePath", fs::controllers::getAbsolutePath},
     {"filesystem.getRelativePath", fs::controllers::getRelativePath},
     {"filesystem.getPathParts", fs::controllers::getPathParts},
+    {"filesystem.access", fs::controllers::access},
+    {"filesystem.chmod", fs::controllers::chmod},
+    {"filesystem.chown", fs::controllers::chown},
     // Neutralino.os
     {"os.execCommand", os::controllers::execCommand},
     {"os.spawnProcess", os::controllers::spawnProcess},


### PR DESCRIPTION
**Fixes**: #1372 

### Description:

This PR adds support for filesystem.access, filesystem.chmod, and filesystem.chown in neutralinojs, aligning with Node.js's implementation.

### Changes:

- `filesystem.access`: Checks file/directory permissions (read, write, execute).
- `filesystem.chmod`: Changes file/directory permissions.
- `filesystem.chown`: Changes file/directory ownership.
- All these are implemented only for Linux/Mac only

### Testing:

- Added comprehensive test cases in filesystem.spec.js for access, chmod & chown.
