### PR TITLE
Added timestamp field in ``watchFile`` event data. 

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -62,6 +62,7 @@ void __dispatchWatcherEvt(efsw::WatchID watcherId, const std::string& dir,
     evt["id"] = watcherId;
     evt["dir"] = helpers::normalizePath(dirC);
     evt["filename"] = filename;
+    evt["timestamp"] = helpers::getCurrentTimestamp();
     switch (action) {
         case efsw::Actions::Add:
             evt["action"] = "add";

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -2,7 +2,8 @@
 #include <string>
 #include <algorithm>
 #include <sstream>
-#include <time.h>
+#include <chrono>
+#include <iomanip>
 #include <ctype.h>
 
 #include "helpers.h"
@@ -131,19 +132,19 @@ string appModeToStr(settings::AppMode mode) {
 }
 
 string getCurrentTimestamp() {
-    auto now = std::chrono::system_clock::now();
-    auto now_time_t = std::chrono::system_clock::to_time_t(now);
-    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+    auto now = chrono::system_clock::now();
+    auto nowTimeT = chrono::system_clock::to_time_t(now);
+    auto nowMs = chrono::duration_cast<chrono::milliseconds>(
                       now.time_since_epoch())
                       .count() % 1000;
 
-    std::ostringstream oss;
-    oss << std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H:%M:%S")
-        << "." << std::setfill('0') << std::setw(3) << now_ms << "Z";
+    ostringstream oss;
+    oss << put_time(gmtime(&nowTimeT), "%Y-%m-%dT%H:%M:%S")
+        << "." << setfill('0') << setw(3) << nowMs << "Z";
 
     return oss.str();
-
 }
+
 string normalizePath(string &path) {
     #if defined(_WIN32)
     replace(path.begin(), path.end(), '\\', '/');

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -130,6 +130,17 @@ string appModeToStr(settings::AppMode mode) {
     }
 }
 
+string getCurrentTimestamp() {
+    auto now = std::chrono::system_clock::now();
+    auto now_time_t = std::chrono::system_clock::to_time_t(now);
+    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      now.time_since_epoch())
+                      .count() % 1000;
+
+    std::ostringstream oss;
+    oss << std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H:%M:%S")
+        << "." << std::setfill('0') << std::setw(3) << now_ms << "Z";
+}
 string normalizePath(string &path) {
     #if defined(_WIN32)
     replace(path.begin(), path.end(), '\\', '/');

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -140,6 +140,9 @@ string getCurrentTimestamp() {
     std::ostringstream oss;
     oss << std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H:%M:%S")
         << "." << std::setfill('0') << std::setw(3) << now_ms << "Z";
+
+    return oss.str();
+
 }
 string normalizePath(string &path) {
     #if defined(_WIN32)

--- a/helpers.h
+++ b/helpers.h
@@ -34,6 +34,7 @@ vector<string> getModes();
 string appModeToStr(settings::AppMode mode);
 string normalizePath(string &path);
 string unNormalizePath(string &path);
+string getCurrentTimestamp();
 
 #if defined(_WIN32)
 wstring str2wstr(const string &str);


### PR DESCRIPTION
## Description
This PR adds a ``timestamp`` field in the ``watchFile`` event generated by the filesystem ``watcher`` in Neutralinojs. The timestamp follows the ``ISO 8601`` format (``YYYY-MM-DDTHH:mm:ss.sssZ``) and represents the exact time when the file change event occurred.

## Changes proposed
- Added a timestamp field in the ``watchFile`` event payload, formatted in ``ISO 8601`` UTC (Zulu time).
- added ``getCurrentTimestamp()`` function definition in ``helpers.cpp`` and declaration in ``helpers.h``
- Adds ``timestamp`` field in the json return object.

## Event data before
```json
{
  "action": "modified",
  "dir": "./resources",
  "filename": "changedFile.txt",
  "id": 1,
}
```
## Event data after
```json
{
  "action": "modified",
  "dir": "./resources",
  "filename": "changedFile.txt",
  "id": 1,
  "timestamp": "2025-02-15T04:14:50.385Z"
}
```
> Conversion into local time format:
```js

    let localTime = new Date(evt.detail.timestamp).toLocaleString();
    console.log("LOCAL TIME: ",localTime);  //2/15/2025, 9:44:50 AM
```


## How to test it
- Build and run the updated NeutralinoJS framework.
- Create a test NeutralinoJS application that listens for watchFile events.
- Modify a file in the watched directory and observe the console output.
- Verify that the emitted event contains a properly formatted timestamp field.

## Next steps
Docs PR: https://github.com/neutralinojs/neutralinojs.github.io/pull/379

None.

## Deploy notes


None.
