### PR TITLE
:bug: Windows: Fix NE_FS_NOPATHE errors when using server.mount on a path that contains non-ASCII symbols

### DIFF
--- a/server/router.cpp
+++ b/server/router.cpp
@@ -228,11 +228,12 @@ errors::StatusCode mountPath(string &path, string &target) {
         path = "/";
     }
 
-    const auto targetFsPath = filesystem::path(CONVSTR(target));
-    if(!filesystem::exists(targetFsPath)) {
+    const auto targetPath = filesystem::path(CONVSTR(target));
+    
+    if(!filesystem::exists(targetPath)) {
         return errors::NE_FS_NOPATHE;
     }
-    if(!filesystem::is_directory(targetFsPath)) {
+    if(!filesystem::is_directory(targetPath)) {
         return errors::NE_FS_NOTADIR;
     }
     if(router::isMounted(path)) {

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -227,16 +227,18 @@ errors::StatusCode mountPath(string &path, string &target) {
     if(path.empty()) {
         path = "/";
     }
-    if(!filesystem::exists(target)) {
+
+    const auto targetFsPath = filesystem::path(CONVSTR(target));
+    if(!filesystem::exists(targetFsPath)) {
         return errors::NE_FS_NOPATHE;
     }
-    if(!filesystem::is_directory(target)) {
+    if(!filesystem::is_directory(targetFsPath)) {
         return errors::NE_FS_NOTADIR;
     }
     if(router::isMounted(path)) {
         return errors::NE_SR_MPINUSE;
     }
-    
+
     mountedPaths[path] = target;
     return errors::NE_ST_OK;
 }

--- a/spec/server.spec.js
+++ b/spec/server.spec.js
@@ -51,6 +51,26 @@ describe('server.spec: server namespace tests', () => {
             assert.ok(output.fetch1 === 200, 'Expected a file request to a mounted directory before unmounting it to succeed');
             assert.ok(output.fetch2 === 404, 'Expected a file request to an unmounted directory to fail');
         });
+        it('mounts and reads from a directory that has non-latin characters', async () => {
+            runner.run(`
+                const response = {};
+                const targetPath = NL_PATH + '/.tmp/test-mount-сосисочка';
+                await Neutralino.filesystem.createDirectory(targetPath);
+                await Neutralino.filesystem.writeFile(targetPath + '/test.txt', 'Hello');
+
+                await Neutralino.server.mount('/test', targetPath);
+
+                const fetch1 = await fetch('/test/test.txt');
+                response.fetch1 = fetch1.status;
+
+                await Neutralino.server.unmount('/test');
+
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.ok(typeof output === 'object', 'Expected output is an object');
+            assert.ok(output.fetch1 === 200, 'The file request to a mounted directory succeeds');
+        });
     });
 
 });


### PR DESCRIPTION
## Description
Fixes NE_FS_NOPATHE when using `Neutralino.server.mount` with paths that, say, contain cyrillic symbols.

## Changes proposed

 - Use `filesystem::path(CONVSTR(target))` to properly handle paths on Windows
 - Add a test case to ensure the method works with non-latin paths on all systems

## How to test it

 - `npm run test server`

## Next steps
None.

## Deploy notes
None.