### PR TITLE
Fix JSON utf8 parsing crash.

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -47,7 +47,6 @@ extern char **environ;
 #include "api/debug/debug.h"
 #include "api/os/os.h"
 #include "api/window/window.h"
-
 #define NEU_MAX_TRAY_MENU_ITEMS 50
 
 using namespace std;
@@ -114,11 +113,15 @@ os::CommandResult execCommand(string command, const os::ChildProcessOptions &opt
     }
 
     auto stdOutHandler = [&](const char *bytes, size_t n) {
-        commandResult.stdOut += string(bytes, n);
+        const string data = string(bytes, n);
+        const string sanitizedStdOut = helpers::sanitizeUTF8(data);
+        commandResult.stdOut += sanitizedStdOut;
     };
 
     auto stdErrHandler = [&](const char *bytes, size_t n) {
-        commandResult.stdErr += string(bytes, n);
+        const string data = string(bytes, n);
+        const string sanitizedStdErr = helpers::sanitizeUTF8(data);
+        commandResult.stdErr += sanitizedStdErr;
     };
 
     if(!options.background && options.envs.empty()) { 
@@ -164,11 +167,15 @@ pair<int, int> spawnProcess(string command, const os::ChildProcessOptions &optio
 
 
     auto stdOutHandler = [=](const char *bytes, size_t n) {
-        __dispatchSpawnedProcessEvt(virtualPid, "stdOut", string(bytes, n));
+        const string data = string(bytes, n);
+        const string sanitizedStdOut = helpers::sanitizeUTF8(data);
+        __dispatchSpawnedProcessEvt(virtualPid, "stdOut", sanitizedStdOut);
     };
 
     auto stdErrHandler = [=](const char *bytes, size_t n) {
-        __dispatchSpawnedProcessEvt(virtualPid, "stdErr", string(bytes, n));
+        const string data = string(bytes, n);
+        const string sanitizedStdErr = helpers::sanitizeUTF8(data);
+        __dispatchSpawnedProcessEvt(virtualPid, "stdErr", sanitizedStdErr);
     };
 
     if(options.envs.empty()) {

--- a/helpers.h
+++ b/helpers.h
@@ -35,7 +35,7 @@ string appModeToStr(settings::AppMode mode);
 string normalizePath(string &path);
 string unNormalizePath(string &path);
 string getCurrentTimestamp();
-
+string sanitizeUTF8(const string& inputData);
 #if defined(_WIN32)
 wstring str2wstr(const string &str);
 string wstr2str(const wstring &str);


### PR DESCRIPTION
Fixes https://github.com/neutralinojs/neutralinojs/issues/1274
## Description
According to the #1274 The neutralino application crashes due to the uncaught exception of the type error. The error is raised by the ``nlohmann``'s json library when the data to be parsed contains non utf-8 characters. As mentioned in this conversation https://github.com/nlohmann/json/issues/1383. The error is caused when trying to process the ``StdOut`` and ``StdErr`` response generated by the processes from ``execCommand`` and ``spawnProcess`` functions and the processes output can sometimes be complex non utf characters, so there is a need to handle them properly.

The string being sent to this function from here, The ``StdOutHandler`` and ``StdErrHandler``
https://github.com/neutralinojs/neutralinojs/blob/3e4b926860a36a05682beb3d971aa7594155d7cb/api/os/os.cpp#L166

In #1274 The error is caused when listening for ``spawnedProcess`` event and trying to parse the ``evt.detail.data`` this most likely originates from here, when the event is dispatched.
https://github.com/neutralinojs/neutralinojs/blob/3e4b926860a36a05682beb3d971aa7594155d7cb/api/os/os.cpp#L71

more specifically from here, as there is no error handling for checking for invalid data being parsed into a json object.
https://github.com/neutralinojs/neutralinojs/blob/3e4b926860a36a05682beb3d971aa7594155d7cb/api/os/os.cpp#L75


## Changes proposed
- Added a ``sanitizeUTF8`` function in ``helpers.cpp`` and ``helpers.h`` to ensure all output data is valid UTF-8.
- Updated the ``StdOut`` and ``StdErr`` fields of ``commandResult`` to store sanitized data.
- The ``sanitizeUTF8`` function replaces invalid UTF-8 sequences with valid characters. 

## How to test it
While working on this, I realized that the input data could sometimes be really big. To make sure the ``sanitizeUTF8`` function works fast and efficiently, even with large inputs, I ran a benchmark to test its speed and performance. The function handles large amounts of data quickly.

the benchmark for the ``sanitizeUTF8`` function can be seen and executed from here:
https://onecompiler.com/cpp/439wdcew9

## Alternatives
I looked into some of the alternatives for parsing non utf data instead of my own implementation this is what i found.
We could have used well-optimized libraries like 
- [ICU](http://site.icu-project.org/) 
- [Boost.Nowide](https://github.com/boostorg/nowide) for UTF-8 validation and sanitization.

But they might add extra overhead with the external dependencies and ``ICU``(International Components for Unicode) library and boost libraries are not native C++ libraries this idea was dropped. But i am open to incorporating some other header only based unicode parsing libraries. 

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.
