### PR TITLE
feat: add native dragging operation (for usage with the SDK)

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -727,6 +727,34 @@ void move(int x, int y) {
     #endif
 }
 
+void beginDragNative(int x, int y, int button) {
+
+#if defined(__linux__) || defined(__FreeBSD__)
+    gtk_window_begin_move_drag(GTK_WINDOW(windowHandle),
+        button, x, y, GDK_CURRENT_TIME);
+
+#elif defined(_WIN32)
+    ReleaseCapture();
+    SendMessage(windowHandle, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
+
+#elif defined(__APPLE__)
+    NSEvent* ev = ((id(*)(id, SEL, NSUInteger, CGPoint, NSUInteger,
+        NSTimeInterval, NSInteger, BOOL, NSInteger, CGFloat))
+        objc_msgSend)("NSEvent"_cls,
+            "mouseEventWithType:location:"
+            "modifierFlags:timestamp:windowNumber:"
+            "context:eventNumber:clickCount:pressure:"_sel,
+            1 /*NSLeftMouseDown*/,
+            CGPointMake(x, y),
+            0, 0,
+            ((NSInteger(*)(id, SEL))objc_msgSend)
+            (windowHandle, "windowNumber"_sel),
+            nil, 0, 1, 0.0f);
+    ((void (*)(id, SEL, id))objc_msgSend)(windowHandle,
+        "performWindowDragWithEvent:"_sel, ev);
+#endif
+}
+
 window::SizeOptions getSize() {
     int width, height = 0;
     #if defined(__linux__) || defined(__FreeBSD__)
@@ -1337,6 +1365,16 @@ json setMainMenu(const json &input) {
 
     window::setMainMenu(input);
 
+    output["success"] = true;
+    return output;
+}
+
+json beginDrag(const json& input) {
+    json output;
+    int sx = 0, sy = 0;
+    if (helpers::hasField(input, "screenX")) sx = input["screenX"].get<int>();
+    if (helpers::hasField(input, "screenY")) sy = input["screenY"].get<int>();
+    nativeWindow->dispatch([&]() { beginDragNative(sx, sy); });
     output["success"] = true;
     return output;
 }

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -110,6 +110,10 @@ void setMainMenu(const json &menu);
 
 void _close(int exitCode);
 
+void beginDragNative(int screenX,
+    int screenY,
+    int button = 1);
+
 namespace controllers {
 
 json init(const json &input);
@@ -137,6 +141,7 @@ json getPosition(const json &input);
 json setAlwaysOnTop(const json &input);
 json snapshot(const json &input);
 json setMainMenu(const json &input);
+json beginDrag(const json& input);
 
 } // namespace controllers
 

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -67,6 +67,7 @@ map<string, router::NativeMethod> methodMap = {
     {"window.focus", window::controllers::focus},
     {"window.setIcon", window::controllers::setIcon},
     {"window.move", window::controllers::move},
+    {"window.beginDrag", window::controllers::beginDrag},
     {"window.center", window::controllers::center},
     {"window.setSize", window::controllers::setSize},
     {"window.getSize", window::controllers::getSize},


### PR DESCRIPTION
## Description
Adds the window.beginDrag method, allowing for custom titlebars to utilize the native platform APIs when dragging a window. Pairs with the new implementation of setDraggableRegion in the SDK PR (coming soon), allowing for matched behavior when utilizing.
**NOTE:** PLEASE TEST THE APPLE/LINUX IMPLEMENTATION. I've only tested Windows and can confirm everything works as expected. The Apple/Linux code *should* work, but I don't have the right devices to test.

## Changes proposed
 - Add window.beginDrag as a receivable WS event to utilize native window dragging

## How to test it
- Send window.beginDrag over the websocket with the x and y of the mouse position. Moving your mouse around will subsequently move the window. **For a less obtuse test**, pair this with the Neutralino JS SDK with the setDraggableRegion PR I'm about to send to see it in action.

Examples to test with the new SDK function:
```js
// Register a region and exclude a button by ID
const region = await setDraggableRegion('my-draggable-div', {  // alternatively: document.getElementById('my-draggable-div')
  exclude: ['initial-excluded-button'], // alternatively:  exclude: [document.getElementById('initial-excluded-button')]
})

// Exclude additional elements using DOM references or IDs
region.exclusions.add('another-excluded-button')                // ✅ Works
region.exclusions.add(document.getElementById('input-field'))   // ✅ Works
region.exclusions.add(['el1', document.getElementById('el2')])  // ✅ Works
region.exclusions.add('one', ['two', 'three'])                  // ✅ Works (mixed styles)

// Remove a previously excluded element
region.exclusions.remove('another-excluded-button')             // ✅ Works
region.exclusions.remove(['initial-excluded-button'])           // ✅ Works
region.exclusions.remove('input-field', 'nonexistent')          // ✅ Safe: no error on non-registered

// Clear all exclusions
region.exclusions.removeAll()                                   // ✅ Works

// Clear the draggable region
await unsetDraggableRegion('my-draggable-div')

// ❌ Attempt to use exclusions after region has been unset
region.exclusions.add('new-button')                             // ❌ Throws: NE_WD_NOTDRRE
region.exclusions.remove('some-button')                         // ❌ Throws: NE_WD_NOTDRRE
region.exclusions.removeAll()                                   // ❌ Throws: NE_WD_NOTDRRE
```

 - All current spec tests for `window` still pass with this implementation.

## Next steps
PR is incoming to the Neutralino.js JS SDK to utilize this new method of setting a draggable region!

## Deploy notes
None.