### PR TITLE
Add support for additional browser parameters, update window options …

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -950,7 +950,8 @@ void __injectScript() {
 void __createWindow() {
     savedState = windowProps.useSavedState && __loadSavedWindowProps();
 
-    nativeWindow = new webview::webview(windowProps.enableInspector, nullptr, windowProps.transparent);
+    nativeWindow = new webview::webview(windowProps.enableInspector, nullptr, windowProps.transparent,
+        windowProps.additionalBrowserArguments);
     nativeWindow->set_title(windowProps.title);
     if(windowProps.extendUserAgentWith != "") {
         nativeWindow->extend_user_agent(windowProps.extendUserAgentWith);
@@ -1328,6 +1329,9 @@ json init(const json &input) {
 
     if(helpers::hasField(input, "injectClientLibrary"))
         windowProps.injectClientLibrary = input["injectClientLibrary"].get<bool>();
+
+    if(helpers::hasField(input, "additionalBrowserArguments"))
+        windowProps.additionalBrowserArguments = input["additionalBrowserArguments"].get<string>();
 
     __createWindow();
     output["success"] = true;

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -60,6 +60,7 @@ struct WindowOptions {
     bool useSavedState = true;
     bool injectGlobals = false;
     bool injectClientLibrary = false;
+    string additionalBrowserArguments = "";
     string title = "Neutralinojs";
     string url = "https://neutralino.js.org";
     string icon = "";

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -957,7 +957,11 @@ private:
 
 class win32_edge_engine {
 public:
-  win32_edge_engine(bool debug, void *window, bool transparent) {
+  win32_edge_engine(bool debug, void *window, bool transparent, const std::string& additionalBrowserArguments) {
+    if(additionalBrowserArguments != "") {
+        std::wstring wargs = str2wstr(additionalBrowserArguments);
+        SetEnvironmentVariableW(L"WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", wargs.c_str());
+    }
     if (window == nullptr) {
       HINSTANCE hInstance = GetModuleHandle(nullptr);
       HICON icon = (HICON)LoadImage(
@@ -1250,8 +1254,8 @@ namespace webview {
 
 class webview : public browser_engine {
 public:
-  webview(bool debug = false, void *wnd = nullptr, bool transparent = false)
-      : browser_engine(debug, wnd, transparent) {}
+  webview(bool debug = false, void *wnd = nullptr, bool transparent = false, const std::string& additionalBrowserArguments = "")
+      : browser_engine(debug, wnd, transparent, additionalBrowserArguments) {}
 
   void navigate(const std::string url) {
     browser_engine::navigate(url);

--- a/schemas/neutralino.config.schema.json
+++ b/schemas/neutralino.config.schema.json
@@ -204,6 +204,10 @@
             "exitProcessOnClose": {
               "type": "boolean",
               "description": "If this setting is 'true', the app process will exit when the user clicks on the close button. Otherwise, the framework will dispatch the 'windowClose' event."
+            },
+            "additionalBrowserArguments": {
+                "type": "string",
+                "description": "Additional command-line arguments for the WebView2 process."
             }
           }
         },


### PR DESCRIPTION
## Description
This commit aims to enhance the Neutralinojs framework by enabling the passing of additional browser arguments to the WebView2 engine on Windows platforms via the `windowProps.additionalBrowserArguments` option. This allows developers to set parameters such as `--disable-web-security` before the WebView2 instance is created, providing more flexible control over browser behavior.

## Changes proposed
- Modified the `webview` class constructor in `lib/webview/webview.h` to accept an `additionalBrowserArguments` string parameter.
- Modified the `win32_edge_engine` class constructor in `lib/webview/webview.h` to accept and process the `additionalBrowserArguments` parameter.
- Inside the `win32_edge_engine` constructor, `SetEnvironmentVariableW` is called to set the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable with the passed `additionalBrowserArguments` value, ensuring it's set before the WebView2 engine initializes.
- Adjusted the initialization order of the `m_browser` member variable in `win32_edge_engine` to ensure the environment variable is set before the browser instance is created.

## How to test it
1.  **Build the application**: Recompile your Neutralinojs application with the modified code.
2.  **Configure `neutralino.config.json`**: In your `neutralino.config.json` file, add or modify the `additionalBrowserArguments` field for the `window` object, for example:
    ```json
    {
      "window": {
        "additionalBrowserArguments": "--disable-web-security"
      }
    }
    ```
3.  **Run the application**: Launch your Neutralinojs application.
4.  **Verify**: Confirm that the passed browser arguments are effective. For instance, if `--disable-web-security` is set, you can try to perform some cross-origin requests in the WebView2 window that would normally be blocked by the same-origin policy, to confirm that the security policy has been disabled.

## Next steps
- Add the definition for the `additionalBrowserArguments` field in `schemas/neutralino.config.schema.json`.
- Modify `api/window/window.cpp` to parse the `additionalBrowserArguments` field from `neutralino.config.json` and pass it to the `webview::webview` constructor.

## Deploy notes
None.