### PR TITLE
fix(filesystem): Correctly handle Unicode paths on Windows

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -732,8 +732,7 @@ public:
     char *currentExeName = PathFindFileNameA(currentExePath);
 
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wideCharConverter;
-    std::wstring userDataFolder =
-        wideCharConverter.from_bytes(std::getenv("APPDATA"));
+    std::wstring userDataFolder = _wgetenv(L"APPDATA");
     std::wstring currentExeNameW = wideCharConverter.from_bytes(currentExeName);
 
     HRESULT res = CreateCoreWebView2EnvironmentWithOptions(


### PR DESCRIPTION
The application crashes on Windows with a stack buffer overrun (0xc0000409) when the user's profile path contains non-ASCII characters (e.g., C:\Users\Jörg). This causes path-related operations to fail and leads to application instability.

This change resolves the issue by switching to the wide-character (Unicode) version of the Windows API for environment variable retrieval.

**Fixes #1351 (#1279)**

## Description
This pull request addresses a critical stability issue on the Windows platform where the application crashes if a user's Windows profile name includes Unicode characters (such as accents or umlauts). The crash is caused by a buffer overrun when handling the environment variable path for `APPDATA`, which was not correctly processing wide-character strings.

## Changes proposed
- Replaced the standard getenv call with the wide-character equivalent `_wgetenv(L"APPDATA")` to correctly retrieve user profile paths containing Unicode characters.

## How to test it
1. On a Windows machine, create a new local user account with a non-ASCII character in the name (e.g., "Jörg", "José", "Łukasz").

2. Log in as that new user.

3. Run the version of the application before this fix. Observe that it crashes on startup.

4. Now, compile and run the version of the application with this fix.

5. Verify that the application starts successfully and that features relying on the AppData path (like logging or file storage) work as expected.

## Next steps
None.

## Deploy notes
None.