### PR TITLE
Update the getStats function to robustly handle file timestamps across Unix-like and Windows systems

### DIFF
--- a/api/fs/fs.h
+++ b/api/fs/fs.h
@@ -43,6 +43,7 @@ struct FileStats {
     fs::EntryType entryType = fs::EntryTypeOther;
     long long createdAt;
     long long modifiedAt;
+    long long lastWriteTime;
 };
 
 struct DirReaderEntry {


### PR DESCRIPTION
## Description
This PR significantly enhances the file statistics retrieval function, `getStats`, to provide accurate and consistent timestamp data across all supported operating systems (Linux, macOS/FreeBSD, and Windows). This change resolves issues where the returned modification time did not match user expectations (e.g., Windows Explorer).

The function is updated to prioritize retrieval of the true file creation time (Birth Time) where supported by the OS/filesystem.

---

## Changes proposed

- Refactored Unix-like Time Retrieval: Implemented a hierarchy to retrieve the most accurate creation time:
    - Prioritizes `statx()` with `STATX_BTIME` for Linux (on recent kernels/GLIBC).
    - Uses `st_birthtime` for macOS/FreeBSD.
    - Falls back to `st_ctime` (Status Change Time) for older Linux systems.
- Added `lastWriteTime`: Introduced a new field (`fileStats.lastWriteTime`) to consistently return the Last Content Modification Time (`st_mtime` on Unix, `LastWriteTime` on Windows), which aligns with user-facing "Date Modified" fields.
- Maintained `modifiedAt`: Kept the original `fileStats.modifiedAt` field mapped to the internal Metadata Change Time (`st_ctime`/`ChangeTime`) for auditing purposes.

---

## How to test it

To verify the correct retrieval of the new and improved fields, check the output of `getStats` on files where the timestamps have been deliberately altered or observed via system utilities.

1.  Test 1: True Birth Time (Creation Time):
    - On a test file, check that `fileStats.createdAt` reflects the original creation time (on Windows, macOS/FreeBSD, and modern Linux).
2.  Test 2: Last Write Time (Content Modified):
    - Modify the file content and save it.
    - Check that `fileStats.lastWriteTime` is updated to the current time, and that this value matches the time shown in File Explorer/Finder.
3.  Test 3: Metadata Change Time (`modifiedAt`):
    - On a Windows system, change the file's Read-Only attribute (without changing content).
    - Check that `fileStats.modifiedAt` is updated to the current time, while `fileStats.lastWriteTime` remains unchanged.

---

## Next steps
None.

## Deploy notes
None.