### PR TITLE
Migrate to CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 /bin/neutralino-*
 /bin/resources.neu
 /bin/resources/js/neutralino.*
+/build
+/build-*
+/build-arm64
+/build-armhf
 
 # Platform specific 
 Thumbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,253 @@
+cmake_minimum_required(VERSION 3.16)
+project(NeutralinoJS LANGUAGES C CXX)
+set(NEU_VERSION "6.3.0")
+set(NEU_CXX_STANDARD 17)
+
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE NEU_COMMIT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+
+# =========================
+# Source files
+# =========================
+file (GLOB SOURCES *.cpp)
+file(GLOB_RECURSE RECURSIVE_SOURCES
+  auth/*.cpp
+  server/*.cpp
+  api/*.cpp
+  lib/tinyprocess/process.cpp
+  lib/easylogging/easylogging++.cc
+  lib/platformfolders/platform_folders.cpp
+  lib/clip/clip.cpp
+  lib/clip/image.cpp
+  lib/infoware/src/**/*.cpp
+  lib/efsw/src/efsw/*.cpp
+)
+list(APPEND SOURCES ${RECURSIVE_SOURCES})
+
+if(WIN32)
+  set(NEU_OS_NAME "win")
+  file(GLOB_RECURSE OS_SOURCES
+    lib/tinyprocess/process_win.cpp
+    lib/clip/clip_win.cpp
+    lib/efsw/src/efsw/platform/win/*.cpp
+    lib/postject/windows_dummy.res
+  )
+  list(APPEND SOURCES ${OS_SOURCES})
+  
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    message("Building Windows x64 🪟...")
+    set(NEU_SYSTEM_PROCESSOR "x64")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "IA64")
+    message("Building Windows ia64 🪟...")
+    set(NEU_SYSTEM_PROCESSOR "ia64")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "i386" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "i686" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86")
+    message("Building Windows x86 🪟...")
+    set(NEU_SYSTEM_PROCESSOR "x86")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    message("Building Windows arm64 🪟...")
+    set(NEU_SYSTEM_PROCESSOR "arm64")
+  endif()
+elseif(APPLE)
+  set(NEU_OS_NAME "mac")
+  file(GLOB_RECURSE OS_SOURCES
+    lib/tinyprocess/process_unix.cpp
+    lib/clip/clip_osx.mm
+    lib/webview/macwindow.mm
+    lib/efsw/src/efsw/platform/posix/*.cpp
+  )
+  list(APPEND SOURCES ${OS_SOURCES})
+
+  if(DEFINED CMAKE_OSX_ARCHITECTURES AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+    message("Building macOS arm64 🍏...")
+    set(NEU_SYSTEM_PROCESSOR "arm64")
+  elseif(DEFINED CMAKE_OSX_ARCHITECTURES AND CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+    message("Building macOS x64 🍏...")
+    set(NEU_SYSTEM_PROCESSOR "x64")
+  elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    message("Building macOS arm64 🍏...")
+    set(NEU_SYSTEM_PROCESSOR "arm64")
+  else()
+    message("Building macOS x64 🍏...")
+    set(NEU_SYSTEM_PROCESSOR "x64")
+  endif()
+elseif(UNIX)
+  set(NEU_OS_NAME "linux")
+  file(GLOB_RECURSE OS_SOURCES
+    lib/tinyprocess/process_unix.cpp
+    lib/clip/clip_x11.cpp
+    lib/efsw/src/efsw/platform/posix/*.cpp
+  )
+  list(APPEND SOURCES ${OS_SOURCES})
+
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x64")
+    message("Building linux x64 🐧...")
+    set(NEU_SYSTEM_PROCESSOR "x64")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "i386" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "i686" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "i486" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "i586")
+    message("Building linux x86 🐧...")
+    set(NEU_SYSTEM_PROCESSOR "x86")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    message("Building linux arm64 🐧...")
+    set(NEU_SYSTEM_PROCESSOR "arm64")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7l" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "armv8l" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "armhf" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM32")
+    message("Building linux armhf 🐧...")
+    set(NEU_SYSTEM_PROCESSOR "armhf")
+  endif()
+endif()
+list(FILTER SOURCES EXCLUDE REGEX ".*/asio/src/.*")
+
+# =========================
+# Create executable or library
+# =========================
+add_executable(${PROJECT_NAME} ${SOURCES})
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+  OUTPUT_NAME "neutralino-${NEU_OS_NAME}_${NEU_SYSTEM_PROCESSOR}"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/bin"
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/bin"
+)
+
+# =========================
+# Compiler definitions
+# =========================
+target_compile_definitions(${PROJECT_NAME} PRIVATE 
+  NEU_VERSION="${NEU_VERSION}"
+  NEU_COMMIT="${NEU_COMMIT}"
+  ELPP_NO_DEFAULT_LOG_FILE=1
+  ASIO_STANDALONE
+  INFOWARE_VERSION="0.6.0"
+  INFOWARE_USE_X11
+  CLIP_ENABLE_IMAGE
+)
+
+if(WIN32)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE 
+    _WEBSOCKETPP_CPP11_STL_
+    _HAS_STD_BYTE=0
+    TRAY_WINAPI=1
+    UNICODE
+    _UNICODE
+  )
+elseif(APPLE)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE 
+    WEBVIEW_COCOA=1
+    TRAY_APPKIT=1
+    MACOSX_DEPLOYMENT_TARGET=10.7
+  )
+elseif(UNIX)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE 
+    HAVE_XCB_XLIB_H
+    WEBVIEW_GTK=1
+    TRAY_APPINDICATOR=1
+    HAVE_PNG_H
+  )
+endif()
+
+# =========================
+# Include paths
+# =========================
+target_include_directories(${PROJECT_NAME} PUBLIC 
+  ${PROJECT_SOURCE_DIR}
+  ${PROJECT_SOURCE_DIR}/lib
+  ${PROJECT_SOURCE_DIR}/lib/asio/include
+  ${PROJECT_SOURCE_DIR}/lib/infoware/include
+  ${PROJECT_SOURCE_DIR}/lib/efsw/include
+  ${PROJECT_SOURCE_DIR}/lib/efsw/src
+)
+if(WIN32)
+  target_include_directories(${PROJECT_NAME} PRIVATE 
+    ${PROJECT_SOURCE_DIR}/lib/webview/windows
+  )
+endif()
+
+# =========================
+# Compiler options by platform
+# =========================
+if(WIN32)
+    # Windows
+    target_compile_options(${PROJECT_NAME} PRIVATE
+      /utf-8
+      /EHsc
+      /Os
+      /Gy
+    )
+    target_link_options(${PROJECT_NAME} PRIVATE
+      /OPT:REF
+      /OPT:ICF
+      /SUBSYSTEM:WINDOWS
+      /ENTRY:wWinMainCRTStartup
+    )
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      ${PROJECT_SOURCE_DIR}/lib/webview/windows/WebView2LoaderStatic.lib
+      gdi32
+      version
+      Ole32
+      OleAut32
+      wbemuuid
+      ntdll
+      dwmapi
+    )
+elseif(APPLE)
+    # macOS
+    find_library(WebKit_FRAMEWORK WebKit)
+    find_library(COCOA_FRAMEWORK Cocoa)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      ${WebKit_FRAMEWORK}
+      ${COCOA_FRAMEWORK}
+    )
+    target_compile_options(${PROJECT_NAME} PRIVATE
+      -Wno-deprecated-declarations
+      -Os
+    )
+    target_link_options(${PROJECT_NAME} PRIVATE
+      -Wl,-dead_strip
+    )
+elseif(UNIX)
+    # Linux / otros UNIX
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+    pkg_check_modules(GLIB2 REQUIRED glib-2.0)
+    pkg_check_modules(XCB REQUIRED xcb)
+    pkg_check_modules(X11 REQUIRED x11)
+    pkg_check_modules(XRANDR REQUIRED xrandr)
+    
+    target_include_directories(${PROJECT_NAME} PRIVATE 
+      ${GTK3_INCLUDE_DIRS}
+      ${GLIB2_INCLUDE_DIRS}
+      ${XCB_INCLUDE_DIRS}
+      ${X11_INCLUDE_DIRS}
+      ${XRANDR_INCLUDE_DIRS}
+    )
+    
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      ${GTK3_LIBRARIES}
+      ${GLIB2_LIBRARIES}
+      ${XCB_LIBRARIES}
+      ${X11_LIBRARIES}
+      ${XRANDR_LIBRARIES}
+      pthread
+      png
+      stdc++fs
+      dl
+    )
+    target_compile_options(${PROJECT_NAME} PRIVATE 
+      -no-pie
+      -Os
+    )
+    target_link_options(${PROJECT_NAME} PRIVATE
+      -Wl,--gc-sections  # Linux garbage collection
+    )
+endif()
+
+# =========================
+# Additional optional configuration
+# =========================
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_STANDARD ${NEU_CXX_STANDARD}
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)

--- a/cmake/toolchains/linux-aarch64.cmake
+++ b/cmake/toolchains/linux-aarch64.cmake
@@ -1,0 +1,27 @@
+# ================================================================
+# Cross toolchain: Linux → Linux ARM64 (aarch64)
+# ================================================================
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER   aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+set(CMAKE_ASM_COMPILER aarch64-linux-gnu-as)
+
+# Root paths for ARM64
+set(CMAKE_FIND_ROOT_PATH
+    /usr/aarch64-linux-gnu
+    /usr/lib/aarch64-linux-gnu
+    /usr/include/aarch64-linux-gnu
+)
+
+# pkg-config config for ARM64
+set(ENV{PKG_CONFIG_DIR} "")
+set(ENV{PKG_CONFIG_SYSROOT_DIR} "")
+set(ENV{PKG_CONFIG_LIBDIR} "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig")
+
+# Search: use only target paths
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/cmake/toolchains/linux-armhf.cmake
+++ b/cmake/toolchains/linux-armhf.cmake
@@ -1,0 +1,27 @@
+# ================================================================
+# Cross toolchain: Linux → Linux ARM32 (armhf)
+# ================================================================
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER   arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+set(CMAKE_ASM_COMPILER arm-linux-gnueabihf-as)
+
+# Root paths for ARMHF
+set(CMAKE_FIND_ROOT_PATH
+    /usr/arm-linux-gnueabihf
+    /usr/lib/arm-linux-gnueabihf
+    /usr/include/arm-linux-gnueabihf
+)
+
+# pkg-config config for ARMHF
+set(ENV{PKG_CONFIG_DIR} "")
+set(ENV{PKG_CONFIG_SYSROOT_DIR} "")
+set(ENV{PKG_CONFIG_LIBDIR} "/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig")
+
+# Search: use only target paths
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)


### PR DESCRIPTION
## Description
As mentioned in #1466, #1426, `buildzri` is a very cool tool for lightweight multi-platform projects, but at the current state of `Neutralino`, the tool is not enough, and the build time is very long. For this (_and others listed below_), this PR aims to migrate to `CMake` and `Ninja`.

## Changes proposed
 - Replace `buildzri` with `CMake`.
 - Add CMake toolchains for Linux ARM build to speed up compilation time.

## How to use it

### Dependencies

- `CMake` 3.16 or higher.
- `Ninja`

### Building

1. Create a `build` folder.

```bash
mkdir -p build
```

2.  Generate `Ninja` files.

```bash
# Current OS and arch
cmake -DCMAKE_BUILD_TYPE=Release . -G Ninja -B build

# Or Custom toolchain (for cross-compile)
cmake -DCMAKE_BUILD_TYPE=Release . -G Ninja -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/linux-armhf.cmake
```

3. Build using `Ninja` (_you can use `make` if you like, but it's slower_).

```bash
ninja -C build -j$(nproc)
```

The result will be in the `bin/` directory as usual. You can securely delete the `build/` directory after finishing.

## Next steps

Update the GitHub Actions and remove `buildzri` configuration files. I already made some tests at [`this fork`](https://github.com/IsmaCortGtz/neutralinojs/tree/feature/CMake-old), so there shouldn't be a problem.

## Advantages

There are probably more, but I would like to highlight the following two.

### Dependencies compatibility

I think this is the most important one. Apps using buildzri are compiled with only one `g++` (_or any other compiler_) call, so every source file is compiled as the same language and linked at once. 

But the big advantage of modern `C/C++` is that you can compile different languages, build them in steps, and link them together in the same binary using tools like `CMake`.  

I won't be very detailed in this point. You can see #1426 for more details, but I'm currently working in the `Net API`. At first I managed to compile `bearssl` using `buildzri` (_any other library like `mbedtls` is impossible to build with `buildzri`_), but `bearssl` is a pretty old implementation, and some websites won't work for a certificate validation problem, so here the solution is to migrate to `CMake` and `mbedtls`.

This was only the case that I got, but in the future the Neutralino API would grow in many directions, and the ability to use `C` or even `Rust` dependencies would give the project a bigger number of options.


### Build time

The build time was reduced in a very heavy way. Running on my local machine (_Debian 12 - Intel i5 11th_), these were the results:

#### `BuildZri`

```bash
#!/bin/bash
python3 ./scripts/bz.py

# Results using 'time ./build.sh'
real    1m40.225s
user    1m34.976s
sys     0m4.674s
```

#### `CMake`

```bash
#!/bin/bash
mkdir -p build
cmake -DCMAKE_BUILD_TYPE=Release . -G Ninja -B build
ninja -C build -j$(nproc)

# Results using 'time ./build.sh'
real    0m34.815s
user    2m57.331s
sys     0m8.851s
```

I tested in GitHub Actions too (_you can see more detailed logs [`here`](https://github.com/IsmaCortGtz/neutralinojs/actions)_). These were the results (this result represents the whole runner time, which includes dependencies, install, and startup):

| **OS-arch**          | [**BuildZri**](https://github.com/IsmaCortGtz/neutralinojs/actions/runs/19604916625) | [**CMake**](https://github.com/IsmaCortGtz/neutralinojs/actions/runs/18884299671) |
|----------------------|-----------|--------------|
| **linux-x64**        | 2m 55s    | 1m 30s       |
| **linux-arm64**      | 26m 43s   | 3m 27s       |
| **linux-armhf**      | 26m 54s   | 2m 45s       |
| **windows-x64**      | 1m 54s    | 1m 51s       |
| **darwin-x64-arm64** | 4m 58s    | 2m 27s       |
 