### PR TITLE
 #1471  fix: initialize system locale for localized date formats (#1471)

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -160,6 +160,8 @@ class gtk_webkit_engine {
 public:
   gtk_webkit_engine(bool debug, bool openInspector, void *window, bool transparent, const std::string &args)
       : m_window(static_cast<GtkWidget *>(window)) {
+        
+    setlocale(LC_ALL, "");
 
     XInitThreads();
     gtk_init_check(0, NULL);


### PR DESCRIPTION
#1471 
## Description

    This PR fixes issue #1471 where the Neutralinojs Linux binary ignored the system locale for date and time formatting and defaulted to en-US. The app now respects the host OS regional settings.


## Changes proposed

  Added setlocale(LC_ALL, "") during Linux GTK window initialization to inherit system locale settings.


## How to test it

   On Linux (or WSL with GUI), set a non-US locale (e.g. en_GB.UTF-8).
Build and run a test app.
Check <input type="date"> or new Date().toLocaleDateString() in DevTools.
Date should follow the system format (e.g. 22/12/2025).


 

## Next steps
None.

## Deploy notes
None.