### PR TITLE
Issue 1482

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -965,6 +965,13 @@ public:
             switch (msg) {
             case WM_SIZE:
               w->m_browser->resize(hwnd);
+              // Update window region for transparent windows on resize
+              if (GetWindowLong(hwnd, GWL_EXSTYLE) & WS_EX_LAYERED) {
+                RECT rect;
+                GetClientRect(hwnd, &rect);
+                HRGN region = CreateRectRgn(0, 0, rect.right, rect.bottom);
+                SetWindowRgn(hwnd, region, TRUE);
+              }
               if(!windowStateChange) break;
               if(wp == SIZE_MINIMIZED) 
                 windowStateChange(WEBVIEW_WINDOW_MINIMIZED);
@@ -1078,6 +1085,11 @@ public:
       SetWindowLong(m_window, GWL_EXSTYLE, GetWindowLong(m_window, GWL_EXSTYLE) | WS_EX_LAYERED);
       // transparent white, use of environment variable prevents flashing on show
       SetEnvironmentVariable(L"WEBVIEW2_DEFAULT_BACKGROUND_COLOR", L"00FFFFFF");
+      // Fix mouse hit-testing for transparent windows
+      RECT rect;
+      GetClientRect(m_window, &rect);
+      HRGN region = CreateRectRgn(0, 0, rect.right, rect.bottom);
+      SetWindowRgn(m_window, region, TRUE);
     }
 
     // stop the taskbar icon from showing by removing WS_EX_APPWINDOW.


### PR DESCRIPTION
## Description

This PR fixes the mouse event hit-testing issue in transparent windows on Windows where the bottom and right portions of the window were not receiving mouse events. The issue was caused by incorrect hit-testing behavior in layered windows (WS_EX_LAYERED).

Fixes #1482

## Changes proposed

- Added `SetWindowRgn` call during transparent window initialization to properly define the window region for hit-testing
- Added `SetWindowRgn` update in the `WM_SIZE` handler to maintain correct hit-testing after window resize
- Ensures the entire transparent window area correctly receives mouse events including mousemove and click events

## How to test it

- Run specs/tests
- Test on Windows with transparent window:
  ```json
  {
    "modes": {
      "window": {
        "transparent": true,
        "width": 800,
        "height": 600
      }
    }
  }