### PR TITLE
Fix query parameters being dropped in Neutralino.window.create

### DIFF
--- a/server/neuserver.cpp
+++ b/server/neuserver.cpp
@@ -212,6 +212,7 @@ void handleHTTP(websocketpp::connection_hdl handler) {
     con->set_body(routerResponse.data);
     con->replace_header("Content-Type", routerResponse.contentType);
 
+
     if(applyConfigHeaders) {
         __applyConfigHeaders(con);
     }


### PR DESCRIPTION
### Problem
When creating a window with a relative URL that contains search parameters (e.g. `/test.html?a=b&c=d`), the opened window loses the query string and `window.location.search` becomes empty.

### Root cause
The internal HTTP server routed requests using the full resource string returned by the connection, which caused the query string to be discarded when serving the file.

### Fix
This change separates the request path from the query string when routing the resource, while allowing the browser to retain the full URL (including search parameters).

### Result
- Multiple query parameters are preserved correctly
- No behavior change for URLs without query strings
- Minimal and localized fix

Fixes #1480 
