### PR TITLE
 ##1493 fix(windows): resolve click events being blocked in draggable regions

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -903,22 +903,24 @@ void move(int x, int y) {
 }
 
 void beginDragNative() {
-
-    #if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__)
     auto mousePos = computer::getMousePosition();
     gtk_window_begin_move_drag(GTK_WINDOW(windowHandle), 1, mousePos.first, mousePos.second, GDK_CURRENT_TIME);
 
-    #elif defined(_WIN32)
-    ReleaseCapture();
-    SendMessage(windowHandle, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
+#elif defined(_WIN32)
+    POINT startPos;
+    if (GetCursorPos(&startPos)) {
+        ReleaseCapture();
+        PostMessage(windowHandle, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
+    }
 
-    #elif defined(__APPLE__)
+#elif defined(__APPLE__)
     ((void (*)(id, SEL, id))objc_msgSend)(windowHandle,
         "performWindowDragWithEvent:"_sel, 
         ((id (*)(id, SEL))objc_msgSend)(windowHandle,
         "currentEvent"_sel)
         );
-    #endif
+#endif
 }
 
 window::SizeOptions getSize() {

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -903,24 +903,24 @@ void move(int x, int y) {
 }
 
 void beginDragNative() {
-#if defined(__linux__) || defined(__FreeBSD__)
+	#if defined(__linux__) || defined(__FreeBSD__)
     auto mousePos = computer::getMousePosition();
     gtk_window_begin_move_drag(GTK_WINDOW(windowHandle), 1, mousePos.first, mousePos.second, GDK_CURRENT_TIME);
 
-#elif defined(_WIN32)
+	#elif defined(_WIN32)
     POINT startPos;
     if (GetCursorPos(&startPos)) {
         ReleaseCapture();
         PostMessage(windowHandle, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
     }
 
-#elif defined(__APPLE__)
+	#elif defined(__APPLE__)
     ((void (*)(id, SEL, id))objc_msgSend)(windowHandle,
         "performWindowDragWithEvent:"_sel, 
         ((id (*)(id, SEL))objc_msgSend)(windowHandle,
         "currentEvent"_sel)
         );
-#endif
+	#endif
 }
 
 window::SizeOptions getSize() {


### PR DESCRIPTION
#1493
## Description
On Windows, SendMessage with SC_MOVE starts a modal loop that blocks the message queue immediately. This makes it impossible for the WebView to fire click or mouseup events because the drag starts before the click is registered.
I've switched this to PostMessage. This lets the OS queue the drag command so that the JS events can finish processing first

## Changes proposed
Replaced SendMessage with PostMessage in beginDragNative.
Added GetCursorPos check before releasing capture.

## How to test it
Set a div as a draggable region.
Add an onclick listener to that div.
Click it—it should now move the window AND trigger the JS alert/log.

## Next steps
None.

## Deploy notes
None.