### PR TITLE
Modify __findChrome to accept json input

### DIFF
--- a/chrome.cpp
+++ b/chrome.cpp
@@ -45,7 +45,7 @@ string __getDefaultChromeArgs() {
     "--use-mock-keychain";
 }
 
-string __findChrome() {
+string __findChrome(const json &input) {
     string chromePath = "";
     #if defined(__linux__)
     vector<string> chromeBins = {
@@ -98,7 +98,7 @@ string __findChrome() {
 
 void init(const json &input) {
 
-    string chromeCmd = __findChrome();
+    string chromeCmd = __findChrome(input);
 
     if(chromeCmd.empty()) {
         pfd::message("Unable to start Chrome mode",


### PR DESCRIPTION
Fix findChrome usage after json passed to it.

## Description

Build failed in master after latest changes

```cpp
    if(helpers::hasField(input, "chromeBin")) {
        string customBin = input["chromeBin"].get<string>();
        chromeBins.insert(chromeBins.begin(), customBin);
    }
```

## Changes proposed

It is straightforward typo fix. `__findChrome` missing required arguments.

## How to test it

- cmake build

## Next steps

None.

## Deploy notes

None.