### PR TITLE
fixed(#1518) Fix extension handling for zenity

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -280,7 +280,7 @@ vector<string> __extensionsToVector(const json &filters) {
         filtersV.push_back(filter["name"].get<string>());
 		const auto &exts = filter["extensions"];
         string extensions = "";
-        for (auto i = 0; i < exts.size(); ++i) {
+        for (int i = 0; i < exts.size(); i++) {
             extensions += "*." + exts[i].get<string>();
 			if (i + 1 < exts.size()) {
 				extensions += " ";


### PR DESCRIPTION
This changes the` __extensionsToVector` helper function to not produce a trailing space on the last extension, which succeeds in some environments but causes a catastrophic failure in zenity (no dialog, process hangs).

This resolves #1518 

## How to test it
On Manjaro XFCE or another linux operating system with zenity 4.2.1 installed, invoke `showOpenDialog` with one or more filter arguments.

Tests of the dialog and other dialogs on other operating system should also be performed to verify this change did not introduce any issues (unlikely, but can never be too sure).

I built neutralinojs and ran it locally to verify it on my system.

## Next steps
None.

## Deploy notes
None.