### PR TITLE
feat: Add Ctrl+W keyboard shortcut to close application

### DIFF
--- a/bin/resources/js/main.js
+++ b/bin/resources/js/main.js
@@ -26,13 +26,13 @@ Neutralino.events.on("windowClose", () => {
     Neutralino.app.exit();
 });
 
-// // Close app with Ctrl+W keyboard shortcut
-// document.addEventListener("keydown", (event) => {
-//     if (event.ctrlKey && event.key === "w") {
-//         event.preventDefault();
-//         Neutralino.app.exit();
-//     }
-// });
+// Close app with Ctrl+W keyboard shortcut
+document.addEventListener("keydown", (event) => {
+    if (event.ctrlKey && event.key === "w") {
+        event.preventDefault();
+        Neutralino.app.exit();
+    }
+});
 
 Neutralino.events.on("eventFromExtension", (evt) => {
     console.log(`INFO: Test extension said: ${evt.detail}`);


### PR DESCRIPTION
## Description
Fixes #1521

Added `Ctrl+W` keyboard shortcut to close the application window.

## Changes
- Added keydown event listener in [bin/resources/js/main.js](cci:7://file:///c:/Users/malla/OneDrive/Desktop/new-repo/neutralinojs/bin/resources/js/main.js:0:0-0:0)
- Listens for `Ctrl+W` key combination and calls `Neutralino.app.exit()`

## Testing
- Run the app and press `Ctrl+W` - app closes correctly