### PR TITLE
feat: Add option to close all application windows at once

### DIFF
--- a/bin/resources/js/main.js
+++ b/bin/resources/js/main.js
@@ -30,8 +30,6 @@ Neutralino.events.on("windowClose", async () => {
         "QUESTION"
     );
 
-<<<<<<< Updated upstream
-=======
     if (choice === "YES") {
 
         await Neutralino.os.execCommand("taskkill /F /IM neutralino-win_x64.exe");
@@ -41,10 +39,8 @@ Neutralino.events.on("windowClose", async () => {
 
 });
 
+Neutralino.events.on("eventFromExtension", (evt) => {
+    console.log(`INFO: Test extension said: ${evt.detail}`);
+});
 
->>>>>>> Stashed changes
-    Neutralino.events.on("eventFromExtension", (evt) => {
-        console.log(`INFO: Test extension said: ${evt.detail}`);
-    });
-
-    showInfo();
+showInfo();


### PR DESCRIPTION
Fixes #1523


## Description
Added a confirmation dialog when closing the application window that offers options to:
- Close ALL open NeutralinoJS windows
- Close only the current window
- Cancel (keep window open)

## Changes
- Modified [bin/resources/js/main.js](cci:7://file:///c:/Users/malla/OneDrive/Desktop/new-repo/neutralinojs/bin/resources/js/main.js:0:0-0:0)
- Added `showMessageBox` dialog on `windowClose` event
- Used `taskkill` command to close all instances on Windows

## Testing
- Open multiple app instances
- Click close (X) on any window
- Dialog appears with Yes/No/Cancel options