### PR TITLE
Added native loading indicator support for macOS

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -117,12 +117,18 @@ jobs:
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Build    
+    - name: Build
       shell: cmd
       run: |
         mkdir build
         cmake -DCMAKE_BUILD_TYPE=Release . -G "Ninja" -B build
         ninja -C build -j %NUMBER_OF_PROCESSORS%
+
+    - name: Upload Windows artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: neutralino-win_x64
+        path: bin/neutralino-win_x64.exe
 
     - name: Setup Spec Requirements (Build client)
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ if(WIN32)
       /EHsc
       /Os
       /Gy
+      $<IF:$<CONFIG:Debug>,/MTd,/MT>  # Static MSVC runtime (no VC redistributable required)
     )
     target_link_options(${PROJECT_NAME} PRIVATE
       /OPT:REF

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -600,8 +600,8 @@ void __injectScript() {
 bool __createWindow() {
     savedState = windowProps.useSavedState && __loadSavedWindowProps();
 
-    nativeWindow = new webview::webview(windowProps.enableInspector, windowProps.openInspectorOnStartup, 
-        nullptr, windowProps.transparent, windowProps.webviewArgs);
+    nativeWindow = new webview::webview(windowProps.enableInspector, windowProps.openInspectorOnStartup,
+        nullptr, windowProps.transparent, windowProps.webviewArgs, windowProps.loadingIndicator);
     
     if(nativeWindow->get_init_code() == 1) {
         return false;
@@ -1286,6 +1286,9 @@ bool init(const json &windowOptions) {
 
     if(helpers::hasField(windowOptions, "skipTaskbar"))
         windowProps.skipTaskbar = windowOptions["skipTaskbar"].get<bool>();
+
+    if(helpers::hasField(windowOptions, "loadingIndicator"))
+        windowProps.loadingIndicator = windowOptions["loadingIndicator"].get<bool>();
 
     if(!__createWindow()) {
         return false;

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -63,6 +63,7 @@ struct WindowOptions {
     bool injectClientLibrary = false;
     bool useLogicalPixels = false;
     bool skipTaskbar = false;
+    bool loadingIndicator = false;
     string webviewArgs = "";
     string title = "Neutralinojs";
     string url = "https://neutralino.js.org";

--- a/schemas/neutralino.config.schema.json
+++ b/schemas/neutralino.config.schema.json
@@ -208,6 +208,11 @@
             "webviewArgs": {
                 "type": "string",
                 "description": "Additional command-line arguments for the WebView2 process."
+            },
+            "loadingIndicator": {
+                "type": "boolean",
+                "description": "Shows a native loading indicator (spinner) while the web content is loading. The spinner is automatically hidden when the page finishes loading.",
+                "default": false
             }
           }
         },


### PR DESCRIPTION
Display native loading indicator on macOS (WebView)

Fixes #814

### Description

This PR adds a native macOS loading indicator (spinner) that is displayed while the webview content is loading. This improves the startup experience by avoiding the brief white/blank window that appears during application launch, especially noticeable in both small and large apps.

The loading indicator is implemented using NSProgressIndicator and is shown until the page finishes loading.

### Implementation details

- Introduced a new config option:
      `"loadingIndicator": true`


- When enabled on macOS:
    A container NSView is created.
    The WebView and a centered NSProgressIndicator spinner are added as subviews.
    A WKNavigationDelegate is used to detect when page loading finishes.
    The spinner stops and hides once navigation completes.



### How to test

Enable the loading indicator in neutralino.config.json:

```
{
  "window": {
    "loadingIndicator": true
  }
}
```


Run the app on macOS

Observe the native spinner during startup until the page is fully loaded

### Files changed

api/window/window.cpp – parse loadingIndicator option

api/window/window.h – extend WindowOptions

lib/webview/webview.h – macOS spinner implementation

schemas/neutralino.config.schema.json – config schema update