### PR TITLE
Fix macOS crash on exit

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -693,6 +693,16 @@ bool __createWindow() {
 
 void _close(int exitCode) {
     if(nativeWindow) {
+        #if defined(__APPLE__)
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            if(windowProps.useSavedState) {
+                __saveWindowProps();
+            }
+            nativeWindow->terminate(exitCode);
+            delete nativeWindow;
+            nativeWindow = nullptr;
+        });
+        #else   
         if(windowProps.useSavedState) {
             __saveWindowProps();
         }
@@ -701,6 +711,8 @@ void _close(int exitCode) {
         FreeConsole();
         #endif
         delete nativeWindow;
+        nativeWindow = nullptr;
+        #endif
     }
 }
 

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -12,6 +12,7 @@
 
 #elif defined(__APPLE__)
 #include <objc/objc-runtime.h>
+#include <dispatch/dispatch.h>
 #include <CoreFoundation/Corefoundation.h>
 #include <CoreGraphics/CGDisplayConfiguration.h>
 #include <CoreGraphics/CGWindow.h>
@@ -695,24 +696,19 @@ void _close(int exitCode) {
     if(nativeWindow) {
         #if defined(__APPLE__)
         dispatch_sync(dispatch_get_main_queue(), ^{
-            if(windowProps.useSavedState) {
-                __saveWindowProps();
-            }
-            nativeWindow->terminate(exitCode);
-            delete nativeWindow;
-            nativeWindow = nullptr;
-        });
-        #else   
+		#endif
         if(windowProps.useSavedState) {
             __saveWindowProps();
         }
         nativeWindow->terminate(exitCode);
+		#if defined(__APPLE__)
+		});
+		#endif
         #if defined(_WIN32)
         FreeConsole();
         #endif
         delete nativeWindow;
         nativeWindow = nullptr;
-        #endif
     }
 }
 


### PR DESCRIPTION
Fixes #1469 

## Description

This PR addresses a crash occurring on macOS when Neutralino.app.exit() is called.

The Root Cause: Threading Violation: app.exit() is triggered from the background WebSocket thread, but AppKit requires that UI operations specifically saving window state and terminating the window occur exclusively on the Main Thread.



## Changes proposed

 - api/window/window.cpp: Wrapped the _close logic in a dispatch_sync block targeting the Main Queue on macOS. This ensures UI operations happen on the correct thread.
 

## How to test it

  - Build the project on macOS (ARM64/x64) using cmake .
  - Run the generated binary.
  - Open the Developer Tools (Inspector).
  - Execute Neutralino.app.exit() in the console.
  - Expected Result: The application closes instantly and cleanly, with no stack trace or error output in the terminal.

Note on Iteration: In my previous commit, I attempted to resolve the crash by removing the close() call entirely to avoid a suspected double-free. After further testing and feedback, I've refined the fix to focus strictly on the threading violation. This current version keeps all original cleanup logic intact but ensures it executes on the Main Thread, preventing the crash while avoiding any risk of "zombie" processes.
