### PR TITLE
 Add Ctrl+W/Cmd+W keyboard shortcut to close application window 

### DIFF
--- a/bin/resources/js/main.js
+++ b/bin/resources/js/main.js
@@ -30,4 +30,15 @@ Neutralino.events.on("eventFromExtension", (evt) => {
     console.log(`INFO: Test extension said: ${evt.detail}`);
 });
 
+// Handle Ctrl+W (Windows/Linux) and Cmd+W (macOS) to close the application
+document.addEventListener("keydown", (evt) => {
+    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+    const closeShortcut = isMac ? evt.metaKey : evt.ctrlKey;
+    
+    if (closeShortcut && evt.key === "w") {
+        evt.preventDefault();
+        Neutralino.app.exit();
+    }
+});
+
 showInfo();


### PR DESCRIPTION
- Implements standard close window shortcut for all platforms
- Uses Ctrl+W on Windows/Linux and Cmd+W on macOS
- Prevents default browser behavior
- Integrates with Neutralino.app.exit() API
- Platform detection via navigator.platform

## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

 - Change 1
 - Change 2
 - etc..

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->

 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.