### PR TITLE
feat: add Ctrl+W shortcut to close application

### DIFF
--- a/bin/resources/js/main.js
+++ b/bin/resources/js/main.js
@@ -30,4 +30,13 @@ Neutralino.events.on("eventFromExtension", (evt) => {
     console.log(`INFO: Test extension said: ${evt.detail}`);
 });
 
+
+window.addEventListener('keydown', (e) => {
+    //check if ctrlkey is click with 'w' or 'W'
+    if (e.ctrlKey && (e.key === 'w' || e.key === 'W')) {         
+        e.preventDefault(); // it can prevent browser default behavior 
+        Neutralino.app.exit(); //this close application
+    }
+});
+
 showInfo();


### PR DESCRIPTION
### Description
This PR addresses issue #1521 by adding a keyboard shortcut to close the application window.

### Changes
- Added a `keydown` event listener in `resources/js/main.js`.
- Checks for `Ctrl + W` (Windows/Linux) and `Cmd + W` (macOS) to ensure cross-platform compatibility.
- Calls `Neutralino.app.exit()` when triggered.

### Testing
- Verified locally by running the test binary with `--load-dir-res`.
- Confirmed that pressing `Ctrl + W` successfully closes the application window.