### PR TITLE
Added Ctrl + W shortcut to close application window 

### DIFF
--- a/bin/resources/js/main.js
+++ b/bin/resources/js/main.js
@@ -30,4 +30,17 @@ Neutralino.events.on("eventFromExtension", (evt) => {
     console.log(`INFO: Test extension said: ${evt.detail}`);
 });
 
+//Ctrl+W combination to close the window
+document.addEventListener("keydown", (event) => {
+    if (
+        NL_MODE === "window" &&
+        (event.ctrlKey || event.metaKey) &&
+        event.key.toLowerCase() === "w"
+    ) {
+        event.preventDefault();
+        Neutralino.app.exit();
+    }
+});
+
+
 showInfo();


### PR DESCRIPTION
## Description
This PR adds a global keyboard listener in resources/js/main.js to handle the
standard Ctrl+W  shortcut and close the application window using Neutralino.app.exit().

Fixes #1521
