### PR TITLE
Fix Windows MSVC runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ else()
   project(NeutralinoJS LANGUAGES C CXX)
 endif()
 
+# MSVC runtime (FIX for clean Windows)
+if (MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 execute_process(
   COMMAND git rev-parse HEAD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->
Fixes Windows releases failing on clean systems by explicitly configuring the MSVC runtime in CMake when building with Ninja.
## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->
- Force static MSVC runtime (/MT) for Windows builds via CMake.
- Align CMake/Ninja output with previously working BuildZri releases.


## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->
Build on Windows using CMake/Ninja and verify the binary runs without VC++ redistributables.

Confirm with dumpbin /dependents that no MSVC runtime DLLs are required.
 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.

#1536