### PR TITLE
fixed(#1548): window.focus() brings window to front on macOS

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -1432,8 +1432,11 @@ json focus(const json &input) {
     #if defined(__linux__) || defined(__FreeBSD__)
     gtk_window_present(GTK_WINDOW(windowHandle));
     #elif defined(__APPLE__)
+    ((void (*)(id, SEL))objc_msgSend)(
+        ((id(*)(id, SEL))objc_msgSend)("NSApplication"_cls, "sharedApplication"_sel),
+        "activate"_sel);
     ((void (*)(id, SEL, id))objc_msgSend)((id) windowHandle,
-            "orderFront:"_sel, NULL);
+            "makeKeyAndOrderFront:"_sel, NULL);
     #elif defined(_WIN32)
     SetForegroundWindow(windowHandle);
     #endif


### PR DESCRIPTION
## Description

Fix `Neutralino.window.focus()` on macOS to bring the window to front when another app is active.

Fixes https://github.com/neutralinojs/neutralinojs/issues/1548

## Changes proposed

- Call `[NSApplication sharedApplication].activate` to activate the app
- Use `makeKeyAndOrderFront:` instead of `orderFront:` to make the window key window and bring it to front

### Why this fix works

The previous implementation only called `orderFront:`, which did not bring the window to front when another app was active. The fix calls `activate` first, then `makeKeyAndOrderFront:`. This matches `gtk_window_present()` on Linux and `SetForegroundWindow()` on Windows.

## How to test it

1. Launch the Neutralino app
2. Put another app's window in front of the Neutralino app window
3. Call `Neutralino.window.focus()`
4. Verify the Neutralino window comes to the front
