### PR TITLE
fixed(#991): Add useTemplateIcon option to setTray

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -720,6 +720,10 @@ json setTray(const json &input) {
                     "dataWithBytes:length:"_sel, iconData, iconDataStr.length());
 
         ((void (*)(id, SEL, id))objc_msgSend)(tray.icon, "initWithData:"_sel, nsIconData);
+
+        if(helpers::hasField(input, "useTemplateIcon") && input["useTemplateIcon"].get<bool>()) {
+            ((void (*)(id, SEL, BOOL))objc_msgSend)(tray.icon, "setTemplate:"_sel, YES);
+        }
         #endif
     }
 


### PR DESCRIPTION
## Description

This pull request adds support for macOS template icons in the system tray. Template icons automatically adapt their color based on the menu bar background (light/dark mode), providing a native appearance that matches other system tray icons.

Addresses issue #991.

## Changes proposed

- Add `useTemplateIcon` option to `os.setTray()` that calls `setTemplate:YES` on NSImage when enabled (macOS only)

## How to test it

1. Prepare a tray icon as a black silhouette with transparent background
2. Call `Neutralino.os.setTray({ icon: '/path/to/icon.png', useTemplateIcon: true, menuItems: [...] })`
3. Toggle macOS between light and dark mode
4. Confirm the tray icon color adapts to the menu bar background

## Next steps

- Update documentation to describe the new `useTemplateIcon` option
- Update client library (neutralinojs/neutralino.js) to include the option in TypeScript types

## Deploy notes

This PR should be merged and released together with neutralinojs/neutralino.js#189, which implements the JS side of this feature.
