### PR TITLE
fix: use atomic counter for openFile IDs to prevent reuse after close

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -197,12 +197,12 @@ bool writeFile(const fs::FileWriterOptions &fileWriterOptions) {
 }
 
 int openFile(const string &filename) {
-    int virtualFileId = nextFileId++;
     ifstream *reader = new ifstream(CONVSTR(filename), ios::binary);
     if(!reader->is_open()) {
         delete reader;
         return -1;
     }
+    int virtualFileId = nextFileId.fetch_add(1);
     lock_guard<mutex> guard(openedFilesLock);
     openedFiles[virtualFileId] = reader;
     return virtualFileId;


### PR DESCRIPTION
**Description**

When you open and close files using `filesystem.openFile`, file IDs are generated using `openedFiles.size()`. This works until any file is closed — the map shrinks, the next open reuses an existing ID, and the old `ifstream*` is silently overwritten. Reads from the victim ID now return data from the wrong file with no error.

This PR replaces the `size()` call with an `atomic<int>` counter, the same pattern already used for process IDs in `os.cpp`.

---

**Why the counter approach is needed**

`openedFiles.size()` only produces unique IDs if entries are never removed. The moment `updateOpenedFile` closes a file and erases the map entry, the next `openFile` call computes an ID that may already be occupied. `std::map::operator[]` on an existing key silently replaces the value — no error, no warning, wrong file handle from that point on. The leaked `ifstream*` also holds the OS file descriptor open until process exit, locking the file on Windows.

---

**Changes**

- Add `atomic<int> nextVirtualFileId(0)` alongside the existing `openedFiles` map in `api/fs/fs.cpp`
- Replace `openedFiles.size()` with `nextVirtualFileId++` in `fs::openFile()`

---

**How to test**

1. Open three files via `Neutralino.filesystem.openFile`
2. Close the first one via `updateOpenedFile` with `event: 'close'`
3. Open a fourth file — note the returned ID
4. Read from the third file's ID
5. Confirm data comes from the correct file, not the newly opened one
6. Verify no file descriptor leak across repeated open/close cycles

---

**Deploy notes**

Companion type definition update may be needed in `neutralinojs/neutralino.js` if `openFile` return types are documented there.