### PR TITLE
refactor: Refactored storage tests.

### DIFF
--- a/spec/storage.spec.js
+++ b/spec/storage.spec.js
@@ -1,46 +1,51 @@
 const assert = require('assert');
-
 const runner = require('./runner');
 
 describe('storage.spec: storage namespace tests', () => {
 
+    beforeEach(() => {
+        runner.run(`
+            await Neutralino.storage.clear();
+            await __close('done');
+        `);
+        assert.strictEqual(runner.getOutput(), 'done');
+    });
+
     describe('storage.setData', () => {
 
-        it('sets data without throwing errors', async () => {
+        it('sets data without throwing errors', () => {
             runner.run(`
                 await Neutralino.storage.setData('container', 'value');
                 await __close('done');
             `);
-            assert.ok(runner.getOutput() == 'done');
+            assert.strictEqual(runner.getOutput(), 'done');
         });
 
-        it('throws an error for invalid keys', async () => {
+        it('throws an error for invalid keys', () => {
             runner.run(`
                 try {
                     await Neutralino.storage.setData('/home/', 'value');
-                }
-                catch(err) {
+                } catch(err) {
                     await __close(err.code);
                 }
             `);
-            assert.ok(runner.getOutput() == 'NE_ST_INVSTKY');
+            assert.strictEqual(runner.getOutput(), 'NE_ST_INVSTKY');
         });
 
-        it('removes storage record when data arg is not provided', async () => {
+        it('removes storage record when data arg is not provided', () => {
             runner.run(`
                 try {
                     await Neutralino.storage.setData('container', 'value');
                     await Neutralino.storage.setData('container');
                     await Neutralino.storage.getData('container');
-                }
-                catch(err) {
+                } catch(err) {
                     await __close(err.code);
                 }
             `);
-            assert.ok(runner.getOutput() == 'NE_ST_NOSTKEX');
+            assert.strictEqual(runner.getOutput(), 'NE_ST_NOSTKEX');
         });
 
-        it('throws an error for invalid datatypes', async () => {
+        it('throws an error for invalid datatypes', () => {
             runner.run(`
                 try {
                     await Neutralino.storage.setData('container', 123);
@@ -48,51 +53,50 @@ describe('storage.spec: storage namespace tests', () => {
                     await __close(error.code);
                 }
             `);
-            assert.ok(runner.getOutput() == 'NE_RT_NATRTER');
+            assert.strictEqual(runner.getOutput(), 'NE_RT_NATRTER');
         });
 
-        it('persists data that is set', async () => {
+        it('persists data that is set', () => {
             runner.run(`
                 await Neutralino.storage.setData('container', 'value');
                 let value = await Neutralino.storage.getData('container');
                 await __close(value);
             `);
-            assert.ok(runner.getOutput() == 'value');
+            assert.strictEqual(runner.getOutput(), 'value');
         });
 
-        it('updates existing data without throwing errors', async () => {
+        it('updates existing data without throwing errors', () => {
             runner.run(`
                 await Neutralino.storage.setData('container', 'initial_value');
                 await Neutralino.storage.setData('container', 'updated_value');
                 let value = await Neutralino.storage.getData('container');
                 await __close(value);
             `);
-            assert.ok(runner.getOutput() == 'updated_value');
+            assert.strictEqual(runner.getOutput(), 'updated_value');
         });
 
-        it('throws an error for empty string key', async () => {
+        it('throws an error for empty string key', () => {
             runner.run(`
                 try {
                     await Neutralino.storage.setData('', 'value');
-                }
-                catch(error) {
+                } catch(error) {
                     await __close(error.code);
                 }
             `);
-            assert.ok(runner.getOutput() == 'NE_ST_INVSTKY');
+            assert.strictEqual(runner.getOutput(), 'NE_ST_INVSTKY');
         });
 
-        it('sets large data values without throwing errors', async () => {
+        it('sets large data values without throwing errors', () => {
             runner.run(`
                 let largeValue = 'N'.repeat(10000); 
                 await Neutralino.storage.setData('large_value_key', largeValue);
                 let value = await Neutralino.storage.getData('large_value_key');
                 await __close(value);
             `);
-            assert.equal(runner.getOutput().length, 10000);
+            assert.strictEqual(runner.getOutput().length, 10000);
         });
-        
-        it('handles concurrent access without errors', async () => {
+
+        it('handles concurrent access without errors', () => {
             runner.run(`
                 await Promise.all([
                     Neutralino.storage.setData('concurrent_key_1', 'value_1'),
@@ -103,45 +107,45 @@ describe('storage.spec: storage namespace tests', () => {
                 await __close(JSON.stringify({value_1, value_2}));
             `);
             const output = JSON.parse(runner.getOutput());
-            assert.ok(output.value_1 == 'value_1' && output.value_2 == 'value_2');
+            assert.strictEqual(output.value_1, 'value_1');
+            assert.strictEqual(output.value_2, 'value_2');
         });
     });
 
     describe('storage.getData', () => {
-        it('gets saved data without throwing errors', async () => {
+
+        it('gets saved data without throwing errors', () => {
             runner.run(`
                 await Neutralino.storage.setData('container', 'value');
                 let value = await Neutralino.storage.getData('container');
                 await __close(value);
             `);
-            assert.ok(runner.getOutput() == 'value');
+            assert.strictEqual(runner.getOutput(), 'value');
         });
 
-        it('throws an error for invalid keys', async () => {
+        it('throws an error for invalid keys', () => {
             runner.run(`
                 try {
-                    await Neutralino.storage.getData('./test*', 'value');
-                }
-                catch(err) {
+                    await Neutralino.storage.getData('./test*');
+                } catch(err) {
                     await __close(err.code);
                 }
             `);
-            assert.ok(runner.getOutput() == 'NE_ST_INVSTKY');
+            assert.strictEqual(runner.getOutput(), 'NE_ST_INVSTKY');
         });
 
-        it('throws an error for keys that don\'t exist', async () => {
+        it('throws an error for keys that don\'t exist', () => {
             runner.run(`
                 try {
-                    await Neutralino.storage.getData('test_key', 'value');
-                }
-                catch(err) {
+                    await Neutralino.storage.getData('test_key');
+                } catch(err) {
                     await __close(err.code);
                 }
             `);
-            assert.ok(runner.getOutput() == 'NE_ST_NOSTKEX');
+            assert.strictEqual(runner.getOutput(), 'NE_ST_NOSTKEX');
         });
-        
-        it('handles concurrent access without errors', async () => {
+
+        it('handles concurrent access without errors', () => {
             runner.run(`
                 await Neutralino.storage.setData('concurrent_key', 'value');
                 let values = await Promise.all([
@@ -154,7 +158,7 @@ describe('storage.spec: storage namespace tests', () => {
             assert.deepStrictEqual(values, ['value', 'value']);
         });
 
-        it('gets JSON data without throwing errors', async () => {
+        it('gets JSON data without throwing errors', () => {
             runner.run(`
                 let jsonData = { name: "test", value: 123 };
                 await Neutralino.storage.setData('json_key', JSON.stringify(jsonData));
@@ -166,29 +170,30 @@ describe('storage.spec: storage namespace tests', () => {
     });
 
     describe('storage.getKeys', () => {
-        it('returns a list of storage keys', async () => {
+
+        it('returns a list of storage keys', () => {
             runner.run(`
                 await Neutralino.storage.setData('test_key_test', 'data');
                 let keys = await Neutralino.storage.getKeys();
                 await __close(JSON.stringify(keys));
             `);
-            let keys = JSON.parse(runner.getOutput());
+            const keys = JSON.parse(runner.getOutput());
             assert.ok(Array.isArray(keys));
-            assert.ok(keys.indexOf('test_key_test') != -1);
+            assert.ok(keys.includes('test_key_test'));
         });
 
-        it('returns all stored keys', async () => {
+        it('returns all stored keys created in this test only', () => {
             runner.run(`
                 await Neutralino.storage.setData('key_1', 'value_1');
                 await Neutralino.storage.setData('key_2', 'value_2');
                 let keys = await Neutralino.storage.getKeys();
                 await __close(JSON.stringify(keys));
             `);
-            let keys = JSON.parse(runner.getOutput());
+            const keys = JSON.parse(runner.getOutput());
             assert.ok(Array.isArray(keys));
-            assert.strictEqual(keys.length, 9);
+            assert.strictEqual(keys.length, 2);
             assert.ok(keys.includes('key_1'));
             assert.ok(keys.includes('key_2'));
-        });     
+        });
     });
 });


### PR DESCRIPTION
## Description
The current storage tests in ``/spec/storage.spec.js`` are coupled together. Tests share a common ``.storage``(sharing a common dir is fine) directory without cleanup. Some tests depend on keys created by previous tests. Reordering tests or running them individually may cause failures. In future if we run the test cases in parallel it can cause failures due to test dependency. Or if the order of execution of tests is change it can also cause failures.

This matters because, test results should not depend on execution order. Future contributors adding tests could unintentionally break existing ones

## Changes proposed
- Added beforeEach hook to clear storage before each test.
- Removed order-dependent assertions.
- Ensured each test verifies only what it creates.
- Made storage.getKeys assertions deterministic.

## How to test it
go to the /spec folder.
run the following commands in order.
- npm install
- npm run test storage


## Deploy notes
None.

I have tried to keep the tests behavior similar to the ones before.