### PR TITLE
fix: memory leaks in the tray management system

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -88,6 +88,20 @@ bool isTrayInitialized() {
 void cleanupTray() {
     if(os::isTrayInitialized()) {
         tray_exit();
+#if defined(_WIN32)
+        if (tray.icon) {
+            DestroyIcon(tray.icon);
+            tray.icon = nullptr;
+        }
+#elif defined(__APPLE__)
+        if (tray.icon) {
+            ((void (*)(id, SEL))objc_msgSend)(tray.icon, sel_registerName("release"));
+            tray.icon = nullptr;
+        }
+#elif defined(__linux__) || defined(__FreeBSD__)
+        delete[] tray.icon;
+        tray.icon = nullptr;
+#endif
     }
 }
 
@@ -733,6 +747,9 @@ json setTray(const json &input) {
         tray.icon = helpers::cStrCopy(fullIconPath);
 
         #elif defined(_WIN32)
+        if (tray.icon) {
+            DestroyIcon(tray.icon);
+        }
         fs::FileReaderResult fileReaderResult = resources::getFile(iconPath);
         string iconDataStr = fileReaderResult.data;
         const char *iconData = iconDataStr.c_str();
@@ -743,6 +760,9 @@ json setTray(const json &input) {
         pStream->Release();
 
         #elif defined(__APPLE__)
+        if (tray.icon) {
+            ((void (*)(id, SEL))objc_msgSend)(tray.icon, sel_registerName("release"));
+        }
         fs::FileReaderResult fileReaderResult = resources::getFile(iconPath);
         string iconDataStr = fileReaderResult.data;
         const char *iconData = iconDataStr.c_str();


### PR DESCRIPTION
## Description
This pull request fixes persistent memory leaks in the tray management system. Previously, tray icon resources (like HICON on Windows and NSImage on macOS) were allocated every time the tray was updated but were never released, leading to increasing memory consumption.


## Changes proposed

   Added platform-specific cleanup logic in setTray
 to release the previous icon before allocating a new one.
Implemented proper resource disposal in cleanupTray to ensure all icon memory is freed when the application closes or the tray is removed.


## How to test it
- Initialize the tray and update the icon multiple times via the API.
- Monitor the application's memory usage to ensure it remains stable instead of growing with each update.
- Close the application and verify that tray resources are correctly released.

 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.