### PR TITLE
Fix Windows sendKey to send key-down event

### DIFF
--- a/api/computer/computer.cpp
+++ b/api/computer/computer.cpp
@@ -168,7 +168,7 @@ bool sendKey(unsigned int keyCode, bool up = true) {
     INPUT in {};
     in.type = INPUT_KEYBOARD;
     in.ki.wVk = vk;
-    in.ki.dwFlags = KEYEVENTF_KEYUP;
+    in.ki.dwFlags = 0;
 
     SendInput(1, &in, sizeof(INPUT));
 


### PR DESCRIPTION
# Summary

The Windows implementation of `computer::sendKey()` in `api/computer/computer.cpp` was sending a key-up event instead of a key-down event on the first `SendInput` call.

Because of this, no actual key press occurred on Windows — only key-up events were sent. As a result, `computer.sendKey()` did not function correctly on Windows, while Linux and macOS behaved as expected.

---

# Fix

Set `dwFlags = 0` for the first `SendInput` call so it correctly sends a key-down event.

### Before

```cpp
in.ki.dwFlags = KEYEVENTF_KEYUP;
```

### After

```cpp
in.ki.dwFlags = 0;  // key-down
```

The existing `if(up)` block already sends the correct `KEYEVENTF_KEYUP` event.

This restores the proper event order (key-down → key-up) and aligns Windows behavior with the Linux and macOS implementations.
