### PR TITLE
Fix race condition in updateSpawnedProcess due to missing mutex lock

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -216,6 +216,7 @@ pair<int, int> spawnProcess(string command, const os::ChildProcessOptions &optio
 }
 
 bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt) {
+    lock_guard<mutex> guard(spawnedProcessesLock);
     if(spawnedProcesses.find(evt.id) == spawnedProcesses.end()) {
         return false;
     }


### PR DESCRIPTION
## Description
`updateSpawnedProcess` was accessing the shared `spawnedProcesses` map and dereferencing
the raw process pointer without holding `spawnedProcessesLock`. This creates a race
condition where the background `processThread` can delete the pointer between the map
lookup and the method call in `updateSpawnedProcess`, leading to undefined behavior.
Every other function that touches `spawnedProcesses` already acquires the lock correctly.

Fixes #1474

## Changes proposed

 - Added `lock_guard<mutex> guard(spawnedProcessesLock)` at the start of `updateSpawnedProcess` to match the locking pattern used consistently across `spawnProcess`, `processThread`, and `getSpawnedProcesses`

## How to test it

 - Spawn a process that reads from stdin like `sqlite3` or `cat`
 - Send input via `stdIn` and then call `stdInEnd` in quick succession
 - Confirm the process handles the stdin close without a crash or unexpected behavior from a corrupted pointer

## Next steps

None.

## Deploy notes

None.