### PR TITLE
fix(windows): restore keyboard focus on window activation (#1491)

### DIFF
--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -863,6 +863,13 @@ public:
     m_controller->put_Bounds(bounds);
   }
 
+  void focus(){
+    if(m_controller == nullptr){
+      return;
+    }
+    m_controller->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
+  }
+
   void navigate(const std::string url) {
     auto wurl = to_lpwstr(url);
     m_webview->Navigate(wurl);
@@ -991,8 +998,10 @@ public:
               if(!windowStateChange) break;
               if(LOWORD(wp) == WA_INACTIVE)
                 windowStateChange(WEBVIEW_WINDOW_BLUR);
-              else
+              else{
                 windowStateChange(WEBVIEW_WINDOW_FOCUS);
+                w->m_browser->focus();
+              }
               break;
             case WM_DESTROY:
               PostQuitMessage(processExitCode);

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -863,13 +863,6 @@ public:
     m_controller->put_Bounds(bounds);
   }
 
-  void focus(){
-    if(m_controller == nullptr){
-      return;
-    }
-    m_controller->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
-  }
-
   void navigate(const std::string url) {
     auto wurl = to_lpwstr(url);
     m_webview->Navigate(wurl);
@@ -1000,7 +993,8 @@ public:
                 windowStateChange(WEBVIEW_WINDOW_BLUR);
               else{
                 windowStateChange(WEBVIEW_WINDOW_FOCUS);
-                w->m_browser->focus();
+				if(m_controller) 
+                	m_controller->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
               }
               break;
             case WM_DESTROY:


### PR DESCRIPTION
## Description
  Fix keyboard input being ignored on Windows when the app window is refocused via the taskbar icon or title bar, without clicking inside the HTML document.

  When the Win32 parent window received `WM_ACTIVATE`, the handler dispatched the `windowFocus` event to JavaScript but never transferred keyboard focus to
  the WebView2 controller. The WebView2 `Chrome_WidgetWin_01` child control requires an explicit `MoveFocus()` call to accept keyboard input.

  Fixes #1491 

  ## Changes proposed

  - Added `focus()` method to `edge_chromium` class that calls `MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC)` on the WebView2 controller
  - Updated `WM_ACTIVATE` handler to call `focus()` when the window is activated, so the WebView2 control receives keyboard focus automatically

  ## How to test it

  - Create a new Neutralino app on Windows
  - Add a `keyup` event listener: `document.addEventListener("keyup", (e) => alert(e.key))`
  - Click outside the app to lose focus
  - Click the app's taskbar icon or title bar (NOT the HTML document) to refocus
  - Press a key — verify it registers without needing to click inside the document

  ## Next steps

  None.

  ## Deploy notes

  None.
  
  ## Demo Video
  
  https://drive.google.com/file/d/1mG4zejkuJpMNw_UE6L7rUSimlIB4vUDU/view?usp=sharing