### PR TITLE
Fix extension processes becoming orphans on app exit

### DIFF
--- a/api/app/app.cpp
+++ b/api/app/app.cpp
@@ -19,6 +19,7 @@
 #include "api/window/window.h"
 #include "api/os/os.h"
 #include "api/events/events.h"
+#include "extensions_loader.h"
 
 using namespace std;
 using json = nlohmann::json;
@@ -26,6 +27,7 @@ using json = nlohmann::json;
 namespace app {
 
 void exit(int code) {
+    extensions::cleanup();
     if(neuserver::isInitialized()) {
         neuserver::stop();
     }

--- a/api/extensions/extensions.cpp
+++ b/api/extensions/extensions.cpp
@@ -61,7 +61,16 @@ json broadcast(const json &input) {
 json getStats(const json &input) {
     json output;
     json stats;
-    stats["loaded"] = extensions::getLoaded();
+    json loaded = json::array();
+    for(const auto &ext : extensions::getLoadedExtensions()) {
+        json extInfo;
+        extInfo["id"] = ext.id;
+        if(ext.virtualPid >= 0) {
+            extInfo["pid"] = ext.virtualPid;
+        }
+        loaded.push_back(extInfo);
+    }
+    stats["loaded"] = loaded;
     stats["connected"] = neuserver::getConnectedExtensions();
 
     output["returnValue"] = stats;

--- a/extensions_loader.cpp
+++ b/extensions_loader.cpp
@@ -10,6 +10,7 @@
 #include "auth/authbasic.h"
 #include "api/os/os.h"
 #include "api/fs/fs.h"
+#include "api/debug/debug.h"
 
 using namespace std;
 using json = nlohmann::json;
@@ -70,6 +71,10 @@ void init() {
 }
 
 void loadOne(const string &extensionId, int virtualPid) {
+    if(extensions::isLoaded(extensionId)) {
+        debug::log(debug::LogTypeError, "Extension '" + extensionId + "' is already loaded");
+        return;
+    }
     loadedExtensions.push_back({extensionId, virtualPid});
 }
 

--- a/extensions_loader.cpp
+++ b/extensions_loader.cpp
@@ -16,7 +16,7 @@ using json = nlohmann::json;
 
 namespace extensions {
 
-vector<string> loadedExtensions;
+vector<LoadedExtension> loadedExtensions;
 bool initialized = false;
 
 json __buildExtensionProcessInput(const string &extensionId) {
@@ -60,29 +60,48 @@ void init() {
             auto process = os::spawnProcess(command, processOptions);
             os::updateSpawnedProcess({process.first, "stdIn", helpers::jsonToString(__buildExtensionProcessInput(extensionId))});
             os::updateSpawnedProcess({process.first, "stdInEnd"});
-            
+            extensions::loadOne(extensionId, process.first);
         }
-
-        extensions::loadOne(extensionId);
+        else {
+            extensions::loadOne(extensionId);
+        }
     }
     initialized = true;
 }
 
-void loadOne(const string &extensionId) {
-    loadedExtensions.push_back(extensionId);
+void loadOne(const string &extensionId, int virtualPid) {
+    loadedExtensions.push_back({extensionId, virtualPid});
 }
 
 vector<string> getLoaded() {
+    vector<string> ids;
+    for(const auto &ext : loadedExtensions) {
+        ids.push_back(ext.id);
+    }
+    return ids;
+}
+
+vector<LoadedExtension> getLoadedExtensions() {
     return loadedExtensions;
 }
 
 bool isLoaded(const string &extensionId) {
-    return find(loadedExtensions.begin(), loadedExtensions.end(), extensionId)
+    return find_if(loadedExtensions.begin(), loadedExtensions.end(),
+            [&](const LoadedExtension &ext){ return ext.id == extensionId; })
             != loadedExtensions.end();
 }
 
 bool isInitialized() {
     return initialized;
+}
+
+void cleanup() {
+    for(const auto &ext : loadedExtensions) {
+        if(ext.virtualPid >= 0) {
+            os::updateSpawnedProcess({ext.virtualPid, "exit"});
+        }
+    }
+    loadedExtensions.clear();
 }
 
 } // namespace extensions

--- a/extensions_loader.h
+++ b/extensions_loader.h
@@ -13,7 +13,7 @@ namespace extensions {
 
 struct LoadedExtension {
     string id;
-    int virtualPid;
+    int virtualPid = -1;
 };
 
 void init();

--- a/extensions_loader.h
+++ b/extensions_loader.h
@@ -11,11 +11,18 @@ using json = nlohmann::json;
 
 namespace extensions {
 
+struct LoadedExtension {
+    string id;
+    int virtualPid;
+};
+
 void init();
-void loadOne(const string &extensionId);
+void loadOne(const string &extensionId, int virtualPid = -1);
 vector<string> getLoaded();
+vector<LoadedExtension> getLoadedExtensions();
 bool isLoaded(const string &extensionId);
 bool isInitialized();
+void cleanup();
 
 } // namesapce extensions
 


### PR DESCRIPTION
Closes neutralinojs/neutralinojs#1567

The core problem was in extensions_loader.cpp. When an extension has a command configured, spawnProcess returns a virtualPid that was only used to send stdin and then thrown away. loadedExtensions was a plain vector of strings with no process handle or pid attached to it. When the app exited nothing signaled those processes so they kept running as orphans.

The fix tracks the virtualPid alongside the extension id in a LoadedExtension struct. A cleanup() function was added that iterates over all loaded extensions and calls updateSpawnedProcess with exit for any that have a valid pid. The app exit handler now calls extensions::cleanup() before stopping the server so all extension processes are terminated cleanly.

getStats() in the extensions controller was also updated to return pid alongside the extension id so callers can know which system process backs each extension.

Files changed: extensions_loader.h, extensions_loader.cpp, api/extensions/extensions.cpp, api/app/app.cpp