### PR TITLE
Add home and desktop to os.getPath()

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -23,6 +23,8 @@
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 #include <unistd.h>
+#include <pwd.h>
+#include <sys/types.h>
 extern char **environ;
 #endif
 
@@ -36,6 +38,7 @@ extern char **environ;
 #include <tchar.h>
 #include <gdiplus.h>
 #include <shlwapi.h>
+#include <shlobj.h>
 
 #pragma comment(lib, "Shell32.lib")
 #pragma comment(lib, "Gdiplus.lib")
@@ -262,6 +265,22 @@ string getPath(const string &name) {
         path = sago::getSaveGamesFolder2();
     else if(name == "temp")
         path = FS_CONVWSTR(filesystem::temp_directory_path());
+    else if(name == "desktop")
+        path = sago::getDesktopFolder();
+    else if(name == "home") {
+        #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+        struct passwd *pw = getpwuid(getuid());
+        if(pw != nullptr) {
+            path = string(pw->pw_dir);
+        }
+        #elif defined(_WIN32)
+        PWSTR homePath = nullptr;
+        if(SHGetKnownFolderPath(FOLDERID_Profile, 0, nullptr, &homePath) == S_OK) {
+            path = helpers::wstr2str(wstring(homePath));
+            CoTaskMemFree(homePath);
+        }
+        #endif
+    }
     return helpers::normalizePath(path);
 }
 

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -270,7 +270,7 @@ string getPath(const string &name) {
     else if(name == "home") {
         #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         struct passwd *pw = getpwuid(getuid());
-        if(pw != nullptr) {
+        if(pw) {
             path = string(pw->pw_dir);
         }
         #elif defined(_WIN32)


### PR DESCRIPTION
Closes neutralinojs/neutralinojs#1568

os.getPath() was missing home and desktop, two paths that almost every desktop app needs at some point. This meant developers had to fall back to os.getEnv("HOME") which is not portable across platforms.

Desktop was straightforward since sago::getDesktopFolder() already exists in the bundled platform folders library, it just was not wired up.

For home, the implementation uses getpwuid(getuid())->pw_dir on Linux and macOS because reading the HOME env var can be wrong when the process was started under sudo or by a launcher that does not set it correctly. On Windows it uses SHGetKnownFolderPath(FOLDERID_Profile) which is the correct modern API.

Both are now available as "home" and "desktop" via os.getPath() on all three platforms.

Files changed: api/os/os.cpp