### PR TITLE
Fix exception slicing by catching std::exception by const reference

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -313,7 +313,7 @@ bool __loadSavedWindowProps() {
         SetWindowPlacement(windowHandle, &wp);
         #endif
     }
-    catch(exception e) {
+    catch(const exception& e) {
         debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_CF_UNBLWCF, string(NEU_WIN_CONFIG_FILE)));
         return false;
     }

--- a/resources.cpp
+++ b/resources.cpp
@@ -129,7 +129,7 @@ bool __makeBundleFileTree() {
     try {
         files = json::parse(headerContent);
     }
-    catch(exception e) {
+    catch(const exception& e) {
         debug::log(debug::LogTypeError, e.what());
     }
     fileTree = files;
@@ -163,7 +163,7 @@ bool __makeEmbeddedFileTree() {
     try {
         files = json::parse(headerContent);
     }
-    catch(exception e) {
+    catch(const exception& e) {
         debug::log(debug::LogTypeError, e.what());
     }
     fileTree = files;

--- a/server/neuserver.cpp
+++ b/server/neuserver.cpp
@@ -189,7 +189,7 @@ void handleMessage(websocketpp::connection_hdl handler, websocketserver::message
             debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_SR_UNBSEND));
         }
     }
-    catch(exception e) {
+    catch(const exception& e) {
         debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_SR_UNBPARS));
     }
 }

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -226,7 +226,7 @@ router::NativeMessage executeNativeMethod(const router::NativeMessage &request) 
             response.data = apiOutput;
             return response;
         }
-        catch(exception e){
+        catch(const exception& e){
             response.data["error"] = errors::makeErrorPayload(errors::NE_RT_NATRTER);
             return response;
         }

--- a/settings.cpp
+++ b/settings.cpp
@@ -72,7 +72,7 @@ bool init() {
             config = json::parse(fileReaderResult.data);
             options = config;
         }
-        catch(exception e) {
+        catch(const exception& e) {
             debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_CF_UNBPRCF, string(configFile)));
             return false;
         }


### PR DESCRIPTION
## Description

All 6 `catch` blocks in the codebase were catching `std::exception` by value (`catch(exception e)`), which causes object slicing. Derived exception data (like `json::parse_error` position info) gets silently lost. Changed them to catch by const reference.

## Changes proposed

- Replaced `catch(exception e)` with `catch(const exception& e)` in 6 locations across 5 files

## How to test it

- Build the project: `cd build && ninja`
- Run `grep -rn "catch(exception e)" --include="*.cpp" --exclude-dir=lib .` to confirm zero matches remain
- Run the test suite: `cd spec && npm test`

## Next steps

None.

## Deploy notes

None.

Close #1572
