### PR TITLE
fix: re-enable full window.setSize tests for all platforms

### DIFF
--- a/spec/window.spec.js
+++ b/spec/window.spec.js
@@ -288,44 +288,31 @@ describe('window.spec: window namespace tests', () => {
         });
     });
 
-    // TODO: Remove this check after fixing: #1080
-    if(process.platform == 'win32') {
     describe('window.setSize', () => {
-        it('exports the function to the app', async () => {
-            runner.run(`
-                await __close(typeof Neutralino.window.setSize);
-            `);
-            assert.equal(runner.getOutput(), 'function');
-        });
+     it('works without throwing errors', async () => {
+        runner.run(`
+            await Neutralino.window.setSize({
+                width: 100,
+                height: 200,
+                minWidth: 20,
+                minHeight: 20,
+                maxWidth: 500,
+                maxHeight: 500,
+                resizable: true
+            });
+            await __close('done');
+        `);
+        assert.equal(runner.getOutput(), 'done');
     });
-    }
-    else {
-    describe('window.setSize', () => {
-        it('works without throwing errors', async () => {
-            runner.run(`
-                await Neutralino.window.setSize({
-                    width: 100,
-                    height: 200,
-                    minWidth: 20,
-                    minHeight: 20,
-                    maxWidth: 500,
-                    maxHeight: 500,
-                    resizable: true
-                });
-                await __close('done');
-            `);
-            assert.equal(runner.getOutput(), 'done');
-        });
 
-        it('doesns\'t throw errors for missing params', async () => {
-            runner.run(`
-                await Neutralino.window.setSize();
-                await __close('done');
-            `);
-            assert.equal(runner.getOutput(), 'done');
-        });
+    it('doesn\'t throw errors for missing params', async () => {
+        runner.run(`
+            await Neutralino.window.setSize();
+            await __close('done');
+        `);
+        assert.equal(runner.getOutput(), 'done');
     });
-    }
+});
 
     describe('window.setAlwaysOnTop', () => {
         it('works without throwing errors', async () => {


### PR DESCRIPTION
## Description
Removed the platform-specific `if/else` conditioning for `window.setSize` tests and the leftover TODO comment. The underlying Windows crash bug (#1080) was fixed in November 2023, but the conditional test block was never cleaned up.

## Changes proposed
- Removed `if(process.platform == 'win32')` conditional block from `window.setSize` tests
- Removed TODO comment referencing issue #1080
- Full `window.setSize` tests now run universally on all platforms including Windows

## How to test it
- Run the window spec tests on Windows and verify `window.setSize` tests pass without platform-specific conditioning

## Next steps
Closes #1566
Relates to #1080

## Deploy notes
None.