### PR TITLE
Fix filesystem.openFile can return duplicate IDs after a file is closed

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <mutex>
+#include <atomic>
 #include <iostream>
 #include <fstream>
 #include <regex>
@@ -41,6 +42,7 @@ using json = nlohmann::json;
 
 map<int, ifstream*> openedFiles;
 mutex openedFilesLock;
+atomic<int> nextVirtualFileId(0);
 efsw::FileWatcher* fileWatcher;
 map<efsw::WatchID, pair<efsw::FileWatchListener*, string>> watchListeners;
 mutex watcherLock;
@@ -195,7 +197,7 @@ bool writeFile(const fs::FileWriterOptions &fileWriterOptions) {
 }
 
 int openFile(const string &filename) {
-    int virtualFileId = openedFiles.size();
+    int virtualFileId = nextVirtualFileId++;
     ifstream *reader = new ifstream(CONVSTR(filename), ios::binary);
     if(!reader->is_open()) {
         delete reader;


### PR DESCRIPTION
 Description
Closes #1578 
openFile was generating virtual file IDs using openedFiles.size(). Once a file gets
closed and removed from the map the size drops, so the next call can return an ID
that already belonged to a previous handle. This causes updateOpenedFile and
getOpenedFileInfo to silently touch the wrong file or fail in confusing ways.

Changes proposed
 - Replaced openedFiles.size() with a std::atomic<int> counter that only ever
   increments, so every openFile call gets a unique ID for the lifetime of the process
   regardless of how many files have been closed in between.

 How to test it
 - Open a file and note the returned ID, then close it.
 - Open another file and confirm the new ID is different from the first.
 - Call getOpenedFileInfo with the second ID and verify it returns the correct data
   with no collision.

 Next steps
None.

 Deploy notes
None.