### PR TITLE
Fix app crashes on macOS when icon path has no leading slash

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -876,7 +876,20 @@ void exitFullScreen() {
 }
 
 void setIcon(const string &iconFile) {
-    fs::FileReaderResult fileReaderResult = resources::getFile(iconFile);
+    string normalizedIconFile = iconFile;
+    if(!normalizedIconFile.empty() && normalizedIconFile[0] != '/') {
+        if(normalizedIconFile.size() > 1 && normalizedIconFile[0] == '.' && normalizedIconFile[1] == '/') {
+            normalizedIconFile = normalizedIconFile.substr(1);
+        }
+        else {
+            normalizedIconFile = "/" + normalizedIconFile;
+        }
+    }
+    fs::FileReaderResult fileReaderResult = resources::getFile(normalizedIconFile);
+    if(fileReaderResult.status != errors::NE_ST_OK) {
+        debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_RS_NOPATHE, normalizedIconFile));
+        return;
+    }
     string iconDataStr = fileReaderResult.data;
     #if defined(__linux__) || defined(__FreeBSD__)
     GdkPixbuf *icon = nullptr;


### PR DESCRIPTION
Description
Closes #1344 
Setting an icon path like "resources/icons/appIcon.png" or "./resources/icons/appIcon.png"
in neutralino.config.json crashes the app on macOS. The resource bundle lookup expects
paths to begin with "/", so without it getFile returns empty data. Passing that empty
data into NSImage initWithData: returns nil, and calling setApplicationIconImage: with
nil throws an uncaught NSException. Windows is more forgiving about this which is why
the same config works fine there.

Changes proposed
 - Normalize the icon path before resource lookup so "resources/x.png" and
   "./resources/x.png" are both treated the same as "/resources/x.png".
 - Return early with a logged error if the file still cannot be found, instead of
   passing empty bytes into the platform icon APIs.

How to test it
 - Set "icon": "resources/icons/appIcon.png" in neutralino.config.json (no leading slash).
 - Run the app on macOS and confirm it no longer crashes and the icon loads correctly.
 - Repeat with "./resources/icons/appIcon.png" and confirm the same result.
 - Confirm that "/resources/icons/appIcon.png" still works as before on all platforms.

Next steps
None.

Deploy notes
None.