### PR TITLE
fix(os): fix tray menu null terminator being overwritten in setTray()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## Unreleased
 
 ### API: computer
-- Implement `computer.getMousePosition(x, y)` to update the current mouse cursor position.
+- Implement `computer.setMousePosition(x, y)` to update the current mouse cursor position.
 - Implement `computer.setMouseGrabbing(grabbing; boolean)` to activate/deactivate confining the mouse cursor within the native app window. If `grabbing` is set to `true`, the mouse cursor always stays within the window boundaries, so this feature helps create interactive games and similar apps operated using the mouse.
 - Implement `computer.sendKey(keyCode, keyState)` to simulate keyboard events. App developers can use a platform-specific key code and states (`press`, `down`, and `up`) to simulate from simple single key strokes to complex key combinations:
 ```js

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -682,7 +682,6 @@ json setTray(const json &input) {
 
     if(helpers::hasField(input, "menuItems")) {
         int menuCount = input["menuItems"].size();
-        menus[menuCount - 1] = { nullptr, nullptr, 0, 0, nullptr, nullptr };
 
         int i = 0;
         for (const auto &menuItem: input["menuItems"]) {
@@ -705,6 +704,8 @@ json setTray(const json &input) {
             menus[i] = { id, text, disabled, checked, __handleTrayMenuItem, nullptr };
             i++;
         }
+        
+        menus[menuCount] = { nullptr, nullptr, 0, 0, nullptr, nullptr };
     }
 
     tray.menu = menus;


### PR DESCRIPTION
## Description
The tray library (`lib/tray/tray.h`) iterates over the `menus` array using a null-terminated loop:
```c
for (; m != NULL && m->text != NULL; m++)
```
This means the last entry must have `text == nullptr` to signal the end of the menu.

In `setTray()`, the null terminator was placed at `menus[menuCount - 1]` **before** the population loop ran. The loop then filled indices `0` through `menuCount - 1`, silently overwriting the terminator with a real menu item. With no terminator present after the loop, the tray library reads past the last valid entry into uninitialised memory.

## Changes proposed
- Moved the null terminator assignment to **after** the menu population loop, at index `menus[menuCount]`, so it is never overwritten

## How to test it
1. Create a Neutralinojs app and call `Neutralino.os.setTray()` with 2 or more menu items
2. Verify all menu items render correctly with no crash or garbage entries at the end
3. Call `setTray()` a second time with a different set of items and confirm the menu updates cleanly

## Next steps
A follow-up PR should add a bounds check to reject `menuItems` arrays longer than `NEU_MAX_TRAY_MENU_ITEMS` (50) before any array access, to prevent a buffer overflow when an oversized menu is passed.

## Deploy notes
None.