### PR TITLE
fix: added stderr error output for silent startup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## Unreleased
 
 ### API: computer
-- Implement `computer.getMousePosition(x, y)` to update the current mouse cursor position.
+- Implement `computer.setMousePosition(x, y)` to update the current mouse cursor position.
 - Implement `computer.setMouseGrabbing(grabbing; boolean)` to activate/deactivate confining the mouse cursor within the native app window. If `grabbing` is set to `true`, the mouse cursor always stays within the window boundaries, so this feature helps create interactive games and similar apps operated using the mouse.
 - Implement `computer.sendKey(keyCode, keyState)` to simulate keyboard events. App developers can use a platform-specific key code and states (`press`, `down`, and `up`) to simulate from simple single key strokes to complex key combinations:
 ```js

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -255,6 +255,12 @@ public:
     }
 
     if(!dlib) {
+      fprintf(stderr, "ERROR: Unable to load WebKit2GTK library. "
+          "Please install libwebkit2gtk-4.0-37 or libwebkit2gtk-4.1-0.\n");
+      const char *err = dlerror();
+      if(err) {
+          fprintf(stderr, "dlopen error: %s\n", err);
+      }
       initCode = 1;
       return;
     }
@@ -823,6 +829,8 @@ public:
         }
     ));
     if (res != S_OK) {
+      fprintf(stderr, "ERROR: Unable to initialize WebView2. HRESULT: 0x%lx\n"
+          "Please install Microsoft Edge WebView2 runtime.\n", (unsigned long)res);
       CoUninitialize();
       return false;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -51,12 +51,14 @@ void __startApp() {
             json windowOptions = options["modes"]["window"];
             windowOptions["url"] = navigationUrl;
             if(!window::init(windowOptions)) {
+                #if defined(_WIN32)
+                string errMsg = "Please install Microsoft Edge WebView2 runtime to run this application.";
+                #else
+                string errMsg = "Please install libwebkit2gtk-4.0-37 or libwebkit2gtk-4.1-0 library to run this application.";
+                #endif
+                fprintf(stderr, "ERROR: Unable to create a webview instance. %s\n", errMsg.c_str());
                 pfd::message("Unable to create a webview instance",
-                    #if defined(_WIN32)
-                    "Please install Microsoft Edge WebView2 runtime to run this application.",
-                    #else
-                    "Please install libwebkit2gtk-4.0-37 or libwebkit2gtk-4.1-0 library to run this application.",
-                    #endif
+                    errMsg,
                     pfd::choice::ok,
                     pfd::icon::error);
                 std::exit(1);
@@ -123,6 +125,7 @@ void __startServerAsync() {
             if(!jPort.is_null()) {
                 errorMsg += " on port: " + to_string(jPort.get<int>());
             }
+            fprintf(stderr, "ERROR: %s\n", errorMsg.c_str());
             pfd::message("Unable to start server",
                 errorMsg,
                 pfd::choice::ok,
@@ -138,6 +141,7 @@ void __initFramework(const json &args) {
     resources::init();
     bool settingsStatus = settings::init();
     if(!settingsStatus) {
+        fprintf(stderr, "ERROR: The application configuration file cannot be loaded due to a JSON parsing error.\n");
         pfd::message("Unable to load configuration",
             "The application configuration file cannot be loaded due to a JSON parsing error.",
             pfd::choice::ok,


### PR DESCRIPTION
## Description

  When webview initialization fails (missing WebView2 on Windows or WebKit2GTK on Linux), the only error reporting was a GUI dialog (`pfd::message`) that
  depends on the very window system that's failing. This causes apps to silently exit with no log, no error, nothing — as reported in #1409 and previously
  in #959.

  This PR adds `fprintf(stderr, ...)` calls to all startup failure paths so errors are always visible when the app is launched from a terminal.

  ## Changes proposed

   - Added stderr output in `lib/webview/webview.h` when `dlopen` fails for WebKit2GTK (Linux) — includes `dlerror()` for the exact reason
   - Added stderr output in `lib/webview/webview.h` when `CreateCoreWebView2EnvironmentWithOptions` fails (Windows) — includes the HRESULT code
   - Added stderr fallback in `main.cpp` before every `pfd::message` + `std::exit(1)` path (webview init, server init, config parse)

  ## How to test it

   - Build the project and run the binary from a terminal on a system without WebKit2GTK (Linux) or WebView2 (Windows 10)
   - Verify the error message appears in stderr instead of a silent exit
   - On a system with all dependencies, verify the app starts normally with no extra output

  ## Next steps

  None.

  ## Deploy notes

  None.

## Demo of the changes:
[demo_of_changes_made](https://drive.google.com/file/d/1NoyI2h-x8b-lnhr5f_g4EtRnL5ihCdGP/view?usp=sharing)