### PR TITLE
fix: fixed input file dialogs do not open for mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## Unreleased
 
 ### API: computer
-- Implement `computer.getMousePosition(x, y)` to update the current mouse cursor position.
+- Implement `computer.setMousePosition(x, y)` to update the current mouse cursor position.
 - Implement `computer.setMouseGrabbing(grabbing; boolean)` to activate/deactivate confining the mouse cursor within the native app window. If `grabbing` is set to `true`, the mouse cursor always stays within the window boundaries, so this feature helps create interactive games and similar apps operated using the mouse.
 - Implement `computer.sendKey(keyCode, keyState)` to simulate keyboard events. App developers can use a platform-specific key code and states (`press`, `down`, and `up`) to simulate from simple single key strokes to complex key combinations:
 ```js

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -604,6 +604,43 @@ public:
           "drawsBackground"_str);
     }
 
+    // UIDelegate for handling file input dialogs (<input type="file">)
+    auto uicls =
+        objc_allocateClassPair((Class) "NSObject"_cls, "WebViewUIDelegate", 0);
+    class_addProtocol(uicls, objc_getProtocol("WKUIDelegate"));
+    class_addMethod(uicls,
+        "webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:"_sel,
+        (IMP)(+[](id, SEL, id, id parameters, id, id completionHandler) {
+            id panel = ((id(*)(id, SEL))objc_msgSend)(
+                "NSOpenPanel"_cls, "openPanel"_sel);
+
+            BOOL allowsMultiple = ((BOOL(*)(id, SEL))objc_msgSend)(
+                parameters, "allowsMultipleSelection"_sel);
+            ((void(*)(id, SEL, BOOL))objc_msgSend)(
+                panel, "setAllowsMultipleSelection:"_sel, allowsMultiple);
+
+            long result = ((long(*)(id, SEL))objc_msgSend)(
+                panel, "runModal"_sel);
+
+            // Block layout (Apple ABI): isa(8) + flags(4) + reserved(4) + invoke(8)
+            auto invoke = *reinterpret_cast<void(**)(void*, id)>(
+                reinterpret_cast<char*>(completionHandler) + 16);
+
+            if (result == 1) { // NSModalResponseOK
+                id urls = ((id(*)(id, SEL))objc_msgSend)(panel, "URLs"_sel);
+                invoke(completionHandler, urls);
+            }
+            else {
+                invoke(completionHandler, nullptr);
+            }
+        }),
+        "v@:@@@@");
+    objc_registerClassPair(uicls);
+
+    auto uidelegate = ((id(*)(id, SEL))objc_msgSend)((id)uicls, "new"_sel);
+    ((void(*)(id, SEL, id))objc_msgSend)(
+        m_webview, "setUIDelegate:"_sel, uidelegate);
+
     ((void (*)(id, SEL, id))objc_msgSend)(m_window, "setContentView:"_sel,
                                           m_webview);
     ((void (*)(id, SEL, id))objc_msgSend)(m_window, "makeKeyAndOrderFront:"_sel,


### PR DESCRIPTION
## Description

 On macOS, clicking `<input type="file">` elements in Neutralinojs apps does nothing — the native file picker never opens. This is because the WKWebView has no `WKUIDelegate` set, so file chooser requests are silently ignored.

closes #1402 

## Changes 
- Added a `WKUIDelegate` to the macOS WKWebView in `lib/webview/webview.h` that handles `webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:` by opening an `NSOpenPanel` and forwarding the selected file URLs back to the webview.

## How to test it

- Build the project on macOS: `mkdir build && cmake . -G Ninja -B build && ninja -C build
- Run the test app: `./bin/neutralino-mac_x64 --load-dir-res`
- Click an `<input type="file">` element — the native file picker should open
- Test with `<input type="file" multiple>` — should allow selecting multiple files
- Press Cancel — should close without hanging or crashing

## Next steps

  None.

## Deploy notes

  None.

## Demo of the changes
https://drive.google.com/file/d/1Ka2tiJ4ru17YsxsnLoptE0b39ra2TyVf/view?usp=sharing
