### PR TITLE
Fix tray icon invisible in built app on Windows   

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## Unreleased
 
 ### API: computer
-- Implement `computer.getMousePosition(x, y)` to update the current mouse cursor position.
+- Implement `computer.setMousePosition(x, y)` to update the current mouse cursor position.
 - Implement `computer.setMouseGrabbing(grabbing; boolean)` to activate/deactivate confining the mouse cursor within the native app window. If `grabbing` is set to `true`, the mouse cursor always stays within the window boundaries, so this feature helps create interactive games and similar apps operated using the mouse.
 - Implement `computer.sendKey(keyCode, keyState)` to simulate keyboard events. App developers can use a platform-specific key code and states (`press`, `down`, and `up`) to simulate from simple single key strokes to complex key combinations:
 ```js

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -714,19 +714,29 @@ json setTray(const json &input) {
         #if defined(__linux__)
         string fullIconPath;
         if(resources::isDirMode()) {
-            fullIconPath = string(filesystem::absolute(settings::joinAppPath(iconPath)));
+            string fullPath = settings::joinAppPath(iconPath);
+            std::error_code ec;
+            if(!filesystem::exists(fullPath, ec) || ec) {
+                output["error"] = errors::makeErrorPayload(errors::NE_RS_NOPATHE, iconPath);
+                return output;
+            }
+            fullIconPath = string(filesystem::absolute(fullPath));
         }
         else {
             // Use alternating tempIconPath since tray_update()
             // doesn't update the icon if the path is the same as the previous one,
             // regardless whether the file contents changed or not.
-            useOtherTempTrayIcon = !useOtherTempTrayIcon;
+            // Compute the target path without committing the toggle yet, so a
+            // failed extraction doesn't corrupt the alternation state.
+            bool nextUseOther = !useOtherTempTrayIcon;
             string tempIconPath = settings::joinAppDataPath(
-                    useOtherTempTrayIcon ?  "/.tmp/tray_icon_linux_01.png" : "/.tmp/tray_icon_linux_02.png"
+                    nextUseOther ? "/.tmp/tray_icon_linux_01.png" : "/.tmp/tray_icon_linux_02.png"
             );
-
-            string tempDirPath = settings::joinAppDataPath("/.tmp");;
-            resources::extractFile(iconPath, tempIconPath);
+            if(!resources::extractFile(iconPath, tempIconPath)) {
+                output["error"] = errors::makeErrorPayload(errors::NE_RS_FILEXTF, iconPath);
+                return output;
+            }
+            useOtherTempTrayIcon = nextUseOther;
             fullIconPath = filesystem::absolute(tempIconPath);
         }
         delete[] tray.icon;
@@ -734,16 +744,42 @@ json setTray(const json &input) {
 
         #elif defined(_WIN32)
         fs::FileReaderResult fileReaderResult = resources::getFile(iconPath);
+        if(fileReaderResult.status != errors::NE_ST_OK) {
+            output["error"] = errors::makeErrorPayload(fileReaderResult.status, iconPath);
+            GdiplusShutdown(gdiplusToken);
+            return output;
+        }
         string iconDataStr = fileReaderResult.data;
         const char *iconData = iconDataStr.c_str();
         unsigned char *uiconData = reinterpret_cast<unsigned char*>(const_cast<char*>(iconData));
-        IStream *pStream = SHCreateMemStream((BYTE *) uiconData, iconDataStr.length());
+        IStream *pStream = SHCreateMemStream((BYTE *) uiconData, static_cast<UINT>(iconDataStr.length()));
+        if(!pStream) {
+            output["error"] = errors::makeErrorPayload(errors::NE_OS_TRAYIER);
+            GdiplusShutdown(gdiplusToken);
+            return output;
+        }
         Gdiplus::Bitmap* bitmap = Gdiplus::Bitmap::FromStream(pStream);
-        bitmap->GetHICON(&tray.icon);
         pStream->Release();
+        if(!bitmap || bitmap->GetLastStatus() != Gdiplus::Ok) {
+            delete bitmap;
+            output["error"] = errors::makeErrorPayload(errors::NE_OS_TRAYIER);
+            GdiplusShutdown(gdiplusToken);
+            return output;
+        }
+        Gdiplus::Status iconStatus = bitmap->GetHICON(&tray.icon);
+        delete bitmap;
+        if(iconStatus != Gdiplus::Ok || tray.icon == NULL) {
+            output["error"] = errors::makeErrorPayload(errors::NE_OS_TRAYIER);
+            GdiplusShutdown(gdiplusToken);
+            return output;
+        }
 
         #elif defined(__APPLE__)
         fs::FileReaderResult fileReaderResult = resources::getFile(iconPath);
+        if(fileReaderResult.status != errors::NE_ST_OK) {
+            output["error"] = errors::makeErrorPayload(fileReaderResult.status, iconPath);
+            return output;
+        }
         string iconDataStr = fileReaderResult.data;
         const char *iconData = iconDataStr.c_str();
         tray.icon =
@@ -752,7 +788,11 @@ json setTray(const json &input) {
         id nsIconData = ((id (*)(id, SEL, const char*, int))objc_msgSend)("NSData"_cls,
                     "dataWithBytes:length:"_sel, iconData, iconDataStr.length());
 
-        ((void (*)(id, SEL, id))objc_msgSend)(tray.icon, "initWithData:"_sel, nsIconData);
+        tray.icon = ((id (*)(id, SEL, id))objc_msgSend)(tray.icon, "initWithData:"_sel, nsIconData);
+        if(!tray.icon) {
+            output["error"] = errors::makeErrorPayload(errors::NE_OS_TRAYIER);
+            return output;
+        }
 
         if(helpers::hasField(input, "useTemplateIcon") && input["useTemplateIcon"].get<bool>()) {
             ((void (*)(id, SEL, BOOL))objc_msgSend)(tray.icon, "setTemplate:"_sel, YES);

--- a/lib/tray/tray.h
+++ b/lib/tray/tray.h
@@ -428,7 +428,7 @@ static void tray_update(struct tray *tray) {
   // because WM_TRAY_CALLBACK_MESSAGE needs it
   SendMessage(hwnd, WM_TRAY_PASS_MENU_REF, (WPARAM)hmenu, 0);
   SendMessage(hwnd, WM_INITMENUPOPUP, (WPARAM)hmenu, 0);
-  if (nid.hIcon) {
+  if (nid.hIcon && nid.hIcon != tray->icon) {
     DestroyIcon(nid.hIcon);
   }
   nid.hIcon = tray->icon;


### PR DESCRIPTION
 ## Summary                                                                                                                                   
  Fixes #1571 — tray icon doesn't appear in the system tray when the app is built with `neu build` (bundle/embedded resource modes), while     
  working correctly with `neu run` (directory mode).                                                                                           

  ### Root Cause
  `resources::getFile(iconPath)` silently fails in bundle/embedded modes when the icon path doesn't resolve to a valid resource. On Windows,
  the entire GDI+ pipeline (`SHCreateMemStream` → `Bitmap::FromStream` → `GetHICON`) produces a NULL HICON with no error propagated, resulting
  in an invisible tray icon.

  ### Changes
  **`api/os/os.cpp` — Add error checking to `setTray` icon loading:**
  - **Windows:** Check `resources::getFile` status, `SHCreateMemStream` return, `Bitmap::FromStream` validity, and `GetHICON` result. Delete
  GDI+ Bitmap after use (memory leak fix).
  - **macOS:** Check `resources::getFile` status and `initWithData:` return value.
  - **Linux (dir mode):** Verify file existence with non-throwing `std::filesystem::exists` overload.
  - **Linux (bundle/embedded):** Check `resources::extractFile` result. Defer `useOtherTempTrayIcon` toggle until after successful extraction
  to prevent state corruption on failure.

  **`lib/tray/tray.h` — Fix use-after-free in `tray_update`:**
  - Only call `DestroyIcon` when the old icon handle differs from the new one, preventing destruction of a still-active icon on menu-only
  updates.