### PR TITLE
fix(os): prevent silent failure in showSaveDialog with invalid defaultPath

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -534,6 +534,22 @@ json showSaveDialog(const json &input) {
     if(helpers::hasField(input, "defaultPath")) {
         defaultPath = input["defaultPath"].get<string>();
         defaultPath = helpers::unNormalizePath(defaultPath);
+
+        std::error_code ec;
+        std::filesystem::path pathObj(CONVSTR(defaultPath));
+        std::filesystem::path dirToCheck = pathObj;
+
+        if (!std::filesystem::is_directory(pathObj, ec)) {
+            dirToCheck = pathObj.parent_path();
+        }
+
+        if (!dirToCheck.empty() && !std::filesystem::exists(dirToCheck, ec)) {
+            std::filesystem::path fallbackPath(CONVSTR(sago::getDocumentsFolder()));
+            if (pathObj.has_filename() && pathObj.filename() != ".") {
+                fallbackPath /= pathObj.filename();
+            }
+            defaultPath = FS_CONVWSTR(fallbackPath);
+        }
     }
 
     string selectedEntry = pfd::save_file(title, defaultPath, filters, option).result();


### PR DESCRIPTION
## Description
Fixes #1352

Currently, if a developer passes a `defaultPath` to `Neutralino.os.showSaveDialog` that points to a non-existent directory, the native dialog wrapper (`portable-file-dialogs`) fails to spawn silently on Windows and Linux (no visual feedback or error payload), and behaves erroneously on macOS.

This PR addresses the silent failure by pre-emptively validating the intended directory via `std::filesystem::exists`. If the provided directory does not exist, the `defaultPath` correctly defaults to the native OS Documents folder (`sago::getDocumentsFolder()`), preserving any explicitly requested filename.

## Changes proposed

 - Validate the base directory of the `defaultPath` using `std::filesystem`.
 - Add a fallback route to the OS default Documents folder if the directory does not exist.
 - Ensure that any requested filename (e.g. `my_file.txt`) inside the invalid path is extracted and preserved during the folder fallback.

## How to test it

 1. Start any Neutralino app.
 2. Call `await Neutralino.os.showSaveDialog('Save file', { defaultPath: '/path/does/not/exist/my_file.txt' });`.
 3. Verify that the native Save dialog successfully opens in the Documents folder and that `my_file.txt` is correctly populated as the default name in the input box. (Before this PR, the dialog would silently fail to open entirely on Windows/Linux).

## Next steps

None.

## Deploy notes

None.
