### PR TITLE
feat(api): add native OS secure storage API (Neutralino.secureStorage)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,15 +205,18 @@ if(WIN32)
       wbemuuid
       ntdll
       dwmapi
+      advapi32
     )
 elseif(APPLE)
     # macOS
     find_library(WebKit_FRAMEWORK WebKit)
     find_library(COCOA_FRAMEWORK Cocoa)
     find_library(SCREENCAPTUREKIT_FRAMEWORK ScreenCaptureKit)
+    find_library(SECURITY_FRAMEWORK Security)
     target_link_libraries(${PROJECT_NAME} PRIVATE
       ${WebKit_FRAMEWORK}
       ${COCOA_FRAMEWORK}
+      ${SECURITY_FRAMEWORK}
     )
     if(SCREENCAPTUREKIT_FRAMEWORK)
       target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -236,6 +239,7 @@ elseif(UNIX)
     pkg_check_modules(X11 REQUIRED x11)
     pkg_check_modules(XRANDR REQUIRED xrandr)
     pkg_check_modules(XTST REQUIRED xtst)
+    pkg_check_modules(LIBSECRET REQUIRED libsecret-1)
     
     target_include_directories(${PROJECT_NAME} PRIVATE 
       ${GTK3_INCLUDE_DIRS}
@@ -244,6 +248,7 @@ elseif(UNIX)
       ${X11_INCLUDE_DIRS}
       ${XRANDR_INCLUDE_DIRS}
       ${XTST_INCLUDE_DIRS}
+      ${LIBSECRET_INCLUDE_DIRS}
     )
     
     target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -253,6 +258,7 @@ elseif(UNIX)
       ${X11_LIBRARIES}
       ${XRANDR_LIBRARIES}
       ${XTST_LIBRARIES}
+      ${LIBSECRET_LIBRARIES}
       pthread
       png
       stdc++fs

--- a/api/secureStorage/secureStorage.cpp
+++ b/api/secureStorage/secureStorage.cpp
@@ -1,0 +1,188 @@
+#include <string>
+
+#if defined(__APPLE__)
+#include <Security/Security.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#include <wincred.h>
+#elif defined(__linux__) || defined(__FreeBSD__)
+#include <libsecret/secret.h>
+#endif
+
+#include "lib/json/json.hpp"
+#include "helpers.h"
+#include "errors.h"
+#include "settings.h"
+#include "api/secureStorage/secureStorage.h"
+
+using namespace std;
+using json = nlohmann::json;
+
+namespace secureStorage {
+
+void init() {
+}
+
+bool setSecureCredential(const string& key, const string& secret) {
+#if defined(__APPLE__)
+    CFStringRef serviceRef = CFStringCreateWithCString(NULL, "neutralinojs", kCFStringEncodingUTF8);
+    CFStringRef keyRef = CFStringCreateWithCString(NULL, key.c_str(), kCFStringEncodingUTF8);
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    
+    CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionaryAddValue(query, kSecAttrService, serviceRef);
+    CFDictionaryAddValue(query, kSecAttrAccount, keyRef);
+    SecItemDelete(query); // Clear existing item before writing
+    
+    CFDataRef dataRef = CFDataCreate(NULL, (const UInt8*)secret.c_str(), secret.length());
+    CFDictionaryAddValue(query, kSecValueData, dataRef);
+    
+    OSStatus status = SecItemAdd(query, NULL);
+    
+    CFRelease(query);
+    CFRelease(keyRef);
+    CFRelease(serviceRef);
+    CFRelease(dataRef);
+    
+    return status == errSecSuccess;
+#elif defined(_WIN32)
+    CREDENTIALA cred = {0};
+    cred.Type = CRED_TYPE_GENERIC;
+    cred.TargetName = (LPSTR)key.c_str();
+    cred.CredentialBlobSize = (DWORD)secret.size();
+    cred.CredentialBlob = (LPBYTE)secret.c_str();
+    cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+    return CredWriteA(&cred, 0) == TRUE;
+#elif defined(__linux__) || defined(__FreeBSD__)
+    GError *error = NULL;
+    static const SecretSchema schema = {
+        "org.neutralino.secureStorage", SECRET_SCHEMA_NONE,
+        {
+            { "key", SECRET_SCHEMA_ATTRIBUTE_STRING },
+            { NULL, SECRET_SCHEMA_ATTRIBUTE_STRING },
+        }
+    };
+    
+    gboolean success = secret_password_store_sync(&schema, SECRET_COLLECTION_DEFAULT,
+                               key.c_str(), secret.c_str(), NULL, &error,
+                               "key", key.c_str(), NULL);
+    if (error != NULL) {
+        g_error_free(error);
+        return false;
+    }
+    return success;
+#else
+    return false;
+#endif
+}
+
+string getSecureCredential(const string& key) {
+#if defined(__APPLE__)
+    CFStringRef serviceRef = CFStringCreateWithCString(NULL, "neutralinojs", kCFStringEncodingUTF8);
+    CFStringRef keyRef = CFStringCreateWithCString(NULL, key.c_str(), kCFStringEncodingUTF8);
+    
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionaryAddValue(query, kSecAttrService, serviceRef);
+    CFDictionaryAddValue(query, kSecAttrAccount, keyRef);
+    CFDictionaryAddValue(query, kSecReturnData, kCFBooleanTrue);
+    CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitOne);
+    
+    CFTypeRef dataTypeRef = NULL;
+    OSStatus status = SecItemCopyMatching(query, &dataTypeRef);
+    
+    string secret = "";
+    if (status == errSecSuccess && dataTypeRef != NULL) {
+        CFDataRef dataRef = (CFDataRef)dataTypeRef;
+        secret = string((const char*)CFDataGetBytePtr(dataRef), CFDataGetLength(dataRef));
+        CFRelease(dataTypeRef);
+    }
+    
+    CFRelease(query);
+    CFRelease(keyRef);
+    CFRelease(serviceRef);
+    return secret;
+#elif defined(_WIN32)
+    PCREDENTIALA pCred;
+    if (CredReadA(key.c_str(), CRED_TYPE_GENERIC, 0, &pCred)) {
+        string secret((char*)pCred->CredentialBlob, pCred->CredentialBlobSize);
+        CredFree(pCred);
+        return secret;
+    }
+    return "";
+#elif defined(__linux__) || defined(__FreeBSD__)
+    GError *error = NULL;
+    static const SecretSchema schema = {
+        "org.neutralino.secureStorage", SECRET_SCHEMA_NONE,
+        {
+            { "key", SECRET_SCHEMA_ATTRIBUTE_STRING },
+            { NULL, SECRET_SCHEMA_ATTRIBUTE_STRING },
+        }
+    };
+    
+    gchar *password = secret_password_lookup_sync(&schema, NULL, &error,
+                                                  "key", key.c_str(), NULL);
+    
+    if (error != NULL) {
+        g_error_free(error);
+        return "";
+    }
+    
+    if (password != NULL) {
+        string secret(password);
+        secret_password_free(password);
+        return secret;
+    }
+    return "";
+#else
+    return "";
+#endif
+}
+
+namespace controllers {
+
+json setData(const json &input) {
+    json output;
+    if(!helpers::hasRequiredFields(input, {"key", "data"})) {
+        output["error"] = errors::makeMissingArgErrorPayload("key or data");
+        return output;
+    }
+    
+    string key = input["key"].get<string>();
+    string data = input["data"].get<string>();
+    
+    string appId = settings::getConfig()["applicationId"].get<string>();
+    string secureKey = appId + "_" + key;
+
+    if (setSecureCredential(secureKey, data)) {
+        output["success"] = true;
+        output["message"] = "Data saved to secure storage";
+    } else {
+        output["error"] = errors::makeErrorPayload(errors::NE_ST_STKEYWE, "Failed to write secure data");
+    }
+    return output;
+}
+
+json getData(const json &input) {
+    json output;
+    if(!helpers::hasRequiredFields(input, {"key"})) {
+        output["error"] = errors::makeMissingArgErrorPayload("key");
+        return output;
+    }
+    
+    string key = input["key"].get<string>();
+    string appId = settings::getConfig()["applicationId"].get<string>();
+    string secureKey = appId + "_" + key;
+
+    string data = getSecureCredential(secureKey);
+    if (!data.empty()) {
+        output["success"] = true;
+        output["returnValue"] = data;
+    } else {
+        output["error"] = errors::makeErrorPayload(errors::NE_ST_NOSTKEX, key);
+    }
+    return output;
+}
+
+} // namespace controllers
+} // namespace secureStorage

--- a/api/secureStorage/secureStorage.h
+++ b/api/secureStorage/secureStorage.h
@@ -1,0 +1,21 @@
+#ifndef NEU_SECURE_STORAGE_H
+#define NEU_SECURE_STORAGE_H
+
+#include "lib/json/json.hpp"
+
+using json = nlohmann::json;
+
+namespace secureStorage {
+
+void init();
+
+namespace controllers {
+
+json setData(const json &input);
+json getData(const json &input);
+
+} // namespace controllers
+
+} // namespace secureStorage
+
+#endif // NEU_SECURE_STORAGE_H

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -29,6 +29,7 @@
 #include "api/res/res.h"
 #include "api/server/server.h"
 #include "api/custom/custom.h"
+#include "api/secureStorage/secureStorage.h"
 
 
 #if defined(__APPLE__)
@@ -139,6 +140,9 @@ map<string, router::NativeMethod> methodMap = {
     {"storage.removeData", storage::controllers::removeData},
     {"storage.getKeys", storage::controllers::getKeys},
     {"storage.clear", storage::controllers::clear},
+    // Neutralino.secureStorage
+    {"secureStorage.setData", secureStorage::controllers::setData},
+    {"secureStorage.getData", secureStorage::controllers::getData},
     // Neutralino.events
     {"events.broadcast", events::controllers::broadcast},
     // Neutralino.extensions


### PR DESCRIPTION
## Description
**Fixes #1593**

Implements a brand-new **Native OS Secure Storage API (`Neutralino.secureStorage`)**.

Currently, the default `Neutralino.storage` namespace persists keys into a plain text generic JSON file (`.storage/` in the app directory). While this works great for trivial window layout preferences, desktop applications frequently need to safely store highly sensitive data (OAuth access tokens, private JWTs, API credentials). Storing these in plain text is a significant security violation for production apps.

This PR implements zero-dependency native Keychain/Credential backend wrappers mapped down directly to each Operating System's secure enclave. Applications can now rely on hardware-backed or OS-backed storage using the lightweight Neutralino footprint without relying on heavy modules like node `keytar`.

## Changes proposed
- **CMakeLists.txt**: Added cross-platform linking dependencies for `Security` (mac), `advapi32` (win), and `libsecret` (linux).
- **api/secureStorage**: Implemented the heavy lifting `SecItemAdd` (macOS), `CredWrite/CredRead` (Windows), and `libsecret` (Linux) integrations.
- **server/router.cpp**: Registered `secureStorage.setData` and `secureStorage.getData` native methods.

## How to test it

Because the frontend typescript wrapper for `Neutralino.secureStorage` needs to be added to the separate [neutralino.js](cci:7://file:///Users/abhiswantchaudhary/Code_Files/GSOC/neutralinojs/test-app/resources/js/neutralino.js:0:0-0:0) client repository in a follow-up PR, you can test this C++ backend implementation directly by dropping this snippet into any neutralino app:

```javascript
// 1. Manually bypass the frontend wrapper to hit the new native endpoint
await window.Neutralino.api.request('secureStorage.setData', { 
    key: 'github_auth', 
    data: 'my_secret_token' 
});

// 2. Retrieve the secret directly from the OS Keychain safely
let auth = await window.Neutralino.api.request('secureStorage.getData', { 
    key: 'github_auth' 
});

console.log("Secure storage retrieval successful:", auth); // Returns { success: true, returnValue: "my_secret_token" }
```
(Note: Ensure you have added "secureStorage.*" to the "nativeAllowList" in your neutralino.config.json before testing).

## Next steps
Requires updates to [neutralino.js](cci:7://file:///Users/abhiswantchaudhary/Code_Files/GSOC/neutralinojs/test-app/resources/js/neutralino.js:0:0-0:0) to expose the new typescript definitions securely to the Vue/React wrappers.

## Deploy notes
Linux packaging distributions may need to explicitly include `libsecret-1-dev` as a build step moving forward.
