### PR TITLE
fix: prevent path traversal in resources.extractFile

### DIFF
--- a/api/res/res.cpp
+++ b/api/res/res.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -173,7 +172,22 @@ json extractFile(const json &input) {
     }
     string path = input["path"].get<string>();
     string destination = input["destination"].get<string>();
-    
+
+    error_code canonicalEc;
+    auto destParent = filesystem::path(CONVSTR(destination)).parent_path();
+    if(destParent.empty()) {
+        destParent = filesystem::current_path();
+    }
+    auto resolvedParent = filesystem::weakly_canonical(destParent, canonicalEc);
+    auto cwdPath = filesystem::current_path();
+    string resolvedStr = FS_CONVWSTR(resolvedParent);
+    string cwdStr = FS_CONVWSTR(cwdPath);
+
+    if(canonicalEc || resolvedStr.rfind(cwdStr, 0) != 0) {
+        output["error"] = errors::makeErrorPayload(errors::NE_RS_FILEXTF, destination);
+        return output;
+    }
+
     if(resources::isBundleMode() && resources::extractFile(path, destination)) {
         output["success"] = true;
     }


### PR DESCRIPTION
## Description

Fixes #1595 — Path traversal vulnerability in `res::controllers::extractFile()`.

The `extractFile()` controller in `api/res/res.cpp` accepted the `destination` parameter from user-provided JSON input and passed it directly to filesystem write operations without any path boundary validation. A malicious client could supply `../` sequences in the destination to write files outside the application's working directory (CWE-22).

## Changes proposed

- Added path traversal sanitization in `res::controllers::extractFile()` using `filesystem::weakly_canonical()` to resolve the destination path and verify it stays within the current working directory
- If the resolved destination escapes `cwd`, the function now returns an `NE_RS_FILEXTF` error and refuses the operation

## How to test it

- Start a Neutralinojs app in bundle or embedded mode
- Send a `resources.extractFile` call with a traversal destination (e.g. `"destination": "../../../tmp/test.html"`) and verify it returns an `NE_RS_FILEXTF` error
- Send a valid destination within the app directory and verify extraction still succeeds
- Run existing specs/tests to confirm no regressions

## Next steps

- Apply the same path traversal validation to `res::controllers::extractDirectory()` which has the same vulnerability

## Deploy notes

None.