### PR TITLE
added static const to map declaration to avoid their rebuilding on every request, improving file serving and API routing

### DIFF
--- a/server/router.cpp
+++ b/server/router.cpp
@@ -202,7 +202,7 @@ router::NativeMessage executeNativeMethod(const router::NativeMessage &request) 
                 response.data["message"] = "Discarded. "+ nativeMethodId + " works within the window mode only";
                 return response;
             }
-            router::NativeMethod nativeMethod = methodMap[nativeMethodId];
+            router::NativeMethod nativeMethod = methodMap.at(nativeMethodId);
             #if defined(__linux__) || defined(_WIN32) || defined(__FreeBSD__)
             json apiOutput;
             #endif
@@ -399,7 +399,9 @@ router::Response getAsset(string path, const string &prependData) {
 
     // If MIME-type is not defined in neuserver, application/octet-stream will be used by default.
     if(mimeTypes.find(extension) != mimeTypes.end()) {
-        response.contentType = mimeTypes[extension];
+        if(mimeTypes.find(extension) != mimeTypes.end()) {
+    response.contentType = mimeTypes.at(extension);
+}
     }
     return response;
 }

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -41,7 +41,7 @@ using json = nlohmann::json;
 
 namespace router {
 
-map<string, router::NativeMethod> methodMap = {
+static const map<string, router::NativeMethod> methodMap = {
     // Neutralino.app
     {"app.exit", app::controllers::exit},
     {"app.killProcess", app::controllers::killProcess},
@@ -171,7 +171,7 @@ map<string, router::NativeMethod> methodMap = {
 
 };
 
-map<string, router::NativeMethod> getMethodMap() {
+map<string, router::NativeMethod> &getMethodMap() {
     return methodMap;
 }
 
@@ -296,7 +296,7 @@ router::Response getAsset(string path, const string &prependData) {
     }
 
     string extension = split[split.size() - 1];
-    map<string, string> mimeTypes = {
+    static const map<string, string> mimeTypes = {
         // Plain text files
         {"css", "text/css"},
         {"csv", "text/csv"},

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -171,7 +171,7 @@ static const map<string, router::NativeMethod> methodMap = {
 
 };
 
-map<string, router::NativeMethod> &getMethodMap() {
+const map<string, router::NativeMethod> &getMethodMap() {
     return methodMap;
 }
 

--- a/server/router.h
+++ b/server/router.h
@@ -31,7 +31,7 @@ struct NativeMessage {
 router::Response serve(string path);
 router::NativeMessage executeNativeMethod(const router::NativeMessage &request);
 router::Response getAsset(string path, const string &prependData = "");
-map<string, router::NativeMethod> getMethodMap();
+const map<string, router::NativeMethod> &getMethodMap();
 errors::StatusCode mountPath(string &path, string &target);
 bool isMounted(const string &path);
 bool unmountPath(string &path);


### PR DESCRIPTION
1. Converted ```map<string, router::NativeMethod> methodMap``` and  ```map<string, string> mimeTypes``` to ```static const map<string, router::NativeMethod> methodMap``` and ```static const map<string, string> mimeTypes``` to avoid the rebuilding of map on every request.

Using static const in declaration of maps helps as now maps are build once and reused forever.
Both maps contain only hardcoded compile-time constants that are never modified, added to, or removed from at runtime.
This increases speed as proven in this test result:
<img width="572" height="183" alt="Screenshot 2026-03-06 185309" src="https://github.com/user-attachments/assets/7a614cab-f5cc-40cc-a554-d080960668e0" />


2. Also the function call of getMethodMap was changed from ```map<string, router::NativeMethod> getMethodMap() { return methodMap; }``` to ```const map<string, router::NativeMethod> &getMethodMap() { return methodMap; }``` to avoid unnecessary copy of map on each call  .
 
3. Changed  ```router::NativeMethod nativeMethod = methodMap[nativeMethodId];``` to ```router::NativeMethod nativeMethod = methodMap.at(nativeMethodId); ```   and ```response.contentType = mimeTypes[extension];``` to ```if(mimeTypes.find(extension) != mimeTypes.end()) {
    response.contentType = mimeTypes.at(extension);
}```
to provide access to the map elements in const type.