### PR TITLE
use static const for fixed regex patterns in neuserver.cpp 

### DIFF
--- a/server/neuserver.cpp
+++ b/server/neuserver.cpp
@@ -165,6 +165,8 @@ void startAsync() {
 
 void stop() {
     server->stop_listening();
+    delete server;
+    server = nullptr;
 }
 
 void handleMessage(websocketpp::connection_hdl handler, websocketserver::message_ptr msg) {


### PR DESCRIPTION
Changed ```bool __isExtensionEndpoint(const string &url) { return regex_match(url, regex(".*extensionId=.*")); }```
, ```bool __hasConnectToken(const string &url) { return regex_match(url, regex(".*connectToken=.*")); }```
,``` if (regex_match(url, regex("^/.*")))```
to ```bool __isExtensionEndpoint(const string &url) {static const regex extensionEndpointPattern(".*extensionId=.*"); return regex_match(url, extensionEndpointPattern); }```
, ```bool __hasConnectToken(const string &url) { static const regex connectTokenPattern(".*connectToken=.*"); return regex_match(url, connectTokenPattern); }```
,```static const regex relativeUrlPattern("^/.*"); if (regex_match(url, relativeUrlPattern))```

As these regex patterns are reconstructed on every server call even though they have constant patterns.
So they are marked with static const hence now they are compiled on first call and reused on subsequent calls.
This increases the speed and reduces delay in performance.
It is similar to the fix done in router.cpp maps .