### PR TITLE
fix: improve test suite reliability and cross-platform support

### DIFF
--- a/spec/index.js
+++ b/spec/index.js
@@ -11,7 +11,8 @@ fs.readdirSync(testDir).filter((file) => file.includes(specModule + '.spec.js'))
       mocha.addFile(path.join(testDir, file));
 
 });
-mocha.timeout(20000);
+const MOCHA_TIMEOUT = process.platform === 'win32' ? 40000 : 20000;
+mocha.timeout(MOCHA_TIMEOUT);
 mocha.run((failures) => {
     process.exitCode = failures ? 1 : 0;
 });

--- a/spec/os.spec.js
+++ b/spec/os.spec.js
@@ -532,7 +532,7 @@ describe('os.spec: os namespace tests', () => {
                 try {
                     await Neutralino.os.open(12345);
                 } catch (error) {
-                    __close(error.code);
+                    await __close(error.code);
                 }
             `);
             assert.equal(runner.getOutput(), 'NE_RT_NATRTER');

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const DEFAULT_TIMEOUT = process.platform === 'win32' ? 40000 : 20000;
 
 const SOURCE_TEMPLATE = `
 {BEFORE_INIT_CODE}
@@ -31,7 +32,7 @@ async function __init() {
     setTimeout(async () => {
         await Neutralino.filesystem.writeFile(NL_PATH + "/.tmp/output.txt", 'NL_SP_MAXTIMT');
         await Neutralino.app.exit(1); // max timeout force exit
-    }, 20000);
+    }, {TIMEOUT});
 }
 `;
 
@@ -81,14 +82,16 @@ function getOutput() {
 
 function makeCommand(optArgs = '') {
     let command = `..${path.sep}bin${path.sep}neutralino-`;
-    if(process.platform == 'linux') {
+    if(process.platform === 'linux') {
         command += 'linux_' + process.arch
     }
-    else if(process.platform == 'darwin') {
+    else if(process.platform === 'darwin') {
         command += 'mac_' + process.arch
     }
-    else if(process.platform == 'win32') {
-        command += 'win_x64.exe'
+    else if(process.platform === 'win32') {
+        command += 'win_' + process.arch + '.exe'
+    }else {
+    throw new Error(`Unsupported platform: ${process.platform}`);
     }
     command += ' --load-dir-res --window-exit-process-on-close ' +
         '--url=/index_spec.html --window-enable-inspector=false ' + optArgs;
@@ -98,7 +101,8 @@ function makeCommand(optArgs = '') {
 function makeAppSource(code, beforeInitCode = '') {
     return SOURCE_TEMPLATE
         .replace('{CODE}', code)
-        .replace('{BEFORE_INIT_CODE}', beforeInitCode);
+        .replace('{BEFORE_INIT_CODE}', beforeInitCode)
+        .replace('{TIMEOUT}', DEFAULT_TIMEOUT);
 }
 
 function cleanup() {


### PR DESCRIPTION
While going through the CI failure logs on PR #1607, I noticed all three network interface tests were failing on Windows with `NL_SP_MAXTIMT` instead of real output. I traced this back to spec/runner.js and found the root cause , the app-level timeout was hardcoded to 20 seconds for all platforms. Windows CI runners take longer to respond for certain APIs, so the timeout fires before the result is written.

While fixing that, I found the same issue in spec/index.js (Mocha timeout), and a separate bug in spec/os.spec.js where a missing `await` was causing the os.open error test to hang indefinitely.

## Changes made

**spec/runner.js**
- Added `DEFAULT_TIMEOUT` constant — 40s on Windows, 20s on Linux/Mac
- Injected via `{TIMEOUT}` placeholder in `makeAppSource()` so the value reaches the Neutralino app as a plain number (the template runs in a separate context from Node.js and cannot access variables directly)
- Windows binary was hardcoded to `win_x64.exe` — changed to use `process.arch` dynamically, same as Linux and Mac
- Added proper error throw for unsupported platforms instead of silently producing a broken command string
- Replaced `==` with `===` for all platform string comparisons

**spec/index.js**
- Mocha timeout was also hardcoded to 20s — applied the same platform-aware fix

**spec/os.spec.js**
- `os.open` error test was missing `await` on `__close(error.code)` in the catch block — without it the async file write never completes and the app hangs until timeout fires

## How to test it

- Run `npm run test app` — 14 passing, 0 failing
<img width="975" height="695" alt="image" src="https://github.com/user-attachments/assets/ef870362-2d7a-480f-9711-1da84f008e37" />

- Run `npm run test os` — 45 passing, 0 failing
<img width="975" height="642" alt="image" src="https://github.com/user-attachments/assets/9c6ac338-cdcf-46bc-b1d8-32ce7ef337d6" />


## Next steps

None.

## Deploy notes

None.

## Related

Timeout issue identified through CI failure in #1607. This fix should help any future API additions pass Windows CI reliably.

Note: `os.execCommand` fails intermittently on Windows regardless of these changes — confirmed pre-existing flaky behavior by testing with and without this fix.