### PR TITLE
feat: add computer.getCPUUsage() API

### DIFF
--- a/api/computer/computer.cpp
+++ b/api/computer/computer.cpp
@@ -1,4 +1,4 @@
-#include <stdint.h>
+#include <cstdint.h>
 #include <string>
 #include "helpers.h"
 #include "errors.h"
@@ -11,6 +11,9 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/XTest.h>
 #include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <unistd.h>
 
 #elif defined(__FreeBSD__)
 #include <unistd.h>
@@ -25,6 +28,7 @@
 #include <sys/sysctl.h>
 #include <CoreGraphics/CoreGraphics.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <mach/mach.h>
 
 #elif defined(_WIN32)
 #define _WINSOCKAPI_
@@ -458,7 +462,91 @@ json sendKey(const json &input) {
     output["success"] = true;
     return output;
 }
+json getCPUUsage(const json &input) {
+    json output;
+    double usage = -1.0;
 
+    #if defined(_WIN32)
+    FILETIME idleTime1, kernelTime1, userTime1;
+    FILETIME idleTime2, kernelTime2, userTime2;
+
+    if(GetSystemTimes(&idleTime1, &kernelTime1, &userTime1)) {
+        Sleep(100);
+        if(GetSystemTimes(&idleTime2, &kernelTime2, &userTime2)) {
+            auto fileTimeToUint64 = [](const FILETIME &ft) -> uint64_t {
+                return ((uint64_t)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+            };
+
+            uint64_t idle   = fileTimeToUint64(idleTime2)   - fileTimeToUint64(idleTime1);
+            uint64_t kernel = fileTimeToUint64(kernelTime2) - fileTimeToUint64(kernelTime1);
+            uint64_t user   = fileTimeToUint64(userTime2)   - fileTimeToUint64(userTime1);
+            uint64_t total  = kernel + user;
+
+            if(total > 0)
+                usage = 100.0 * (1.0 - (double)idle / (double)total);
+        }
+    }
+
+    #elif defined(__linux__)
+    auto readCPUStat = []() -> vector<uint64_t> {
+        ifstream file("/proc/stat");
+        string line;
+        getline(file, line);
+        istringstream ss(line.substr(5));
+        vector<uint64_t> times;
+        uint64_t val;
+        while(ss >> val) times.push_back(val);
+        return times;
+    };
+
+    auto times1 = readCPUStat();
+    usleep(100000);
+    auto times2 = readCPUStat();
+
+    if(!times1.empty() && !times2.empty()) {
+        uint64_t idle1 = times1[3], idle2 = times2[3];
+        uint64_t total1 = 0, total2 = 0;
+        for(auto t : times1) total1 += t;
+        for(auto t : times2) total2 += t;
+
+        uint64_t totalDiff = total2 - total1;
+        uint64_t idleDiff  = idle2  - idle1;
+
+        if(totalDiff > 0)
+            usage = 100.0 * (1.0 - (double)idleDiff / (double)totalDiff);
+    }
+
+    #elif defined(__APPLE__)
+    auto getCPUTicks = [](uint64_t &total, uint64_t &idle) {
+        host_cpu_load_info_data_t cpuInfo;
+        mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
+        if(host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO,
+            (host_info_t)&cpuInfo, &count) == KERN_SUCCESS) {
+            total = 0;
+            for(int i = 0; i < CPU_STATE_MAX; i++)
+                total += cpuInfo.cpu_ticks[i];
+            idle = cpuInfo.cpu_ticks[CPU_STATE_IDLE];
+            return true;
+        }
+        return false;
+    };
+
+    uint64_t total1, idle1, total2, idle2;
+    if(getCPUTicks(total1, idle1)) {
+        usleep(100000);
+        if(getCPUTicks(total2, idle2)) {
+            uint64_t totalDiff = total2 - total1;
+            uint64_t idleDiff  = idle2  - idle1;
+            if(totalDiff > 0)
+                usage = 100.0 * (1.0 - (double)idleDiff / (double)totalDiff);
+        }
+    }
+    #endif
+
+    output["returnValue"]["usage"] = usage;
+    output["success"] = true;
+    return output;
+}
 
 } // namespace controllers
 } // namespace computer

--- a/api/computer/computer.cpp
+++ b/api/computer/computer.cpp
@@ -1,4 +1,4 @@
-#include <cstdint.h>
+#include <cstdint>
 #include <string>
 #include "helpers.h"
 #include "errors.h"

--- a/api/computer/computer.h
+++ b/api/computer/computer.h
@@ -31,7 +31,8 @@ json getDisplays(const json &input);
 json getMousePosition(const json &input);
 json setMousePosition(const json &input);
 json setMouseGrabbing(const json &input);
-json sendKey(const json &input);;
+json sendKey(const json &input);
+json getCPUUsage(const json &input);
 
 } // namespace controllers
 } // namespace computer

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -84,6 +84,7 @@ map<string, router::NativeMethod> methodMap = {
     {"computer.getKernelInfo", computer::controllers::getKernelInfo},
     {"computer.getOSInfo", computer::controllers::getOSInfo},
     {"computer.getCPUInfo", computer::controllers::getCPUInfo},
+    {"computer.getCPUUsage", computer::controllers::getCPUUsage},
     {"computer.getDisplays", computer::controllers::getDisplays},
     {"computer.getMousePosition", computer::controllers::getMousePosition},
     {"computer.setMousePosition", computer::controllers::setMousePosition},
@@ -211,7 +212,7 @@ router::NativeMessage executeNativeMethod(const router::NativeMessage &request) 
             // In macos, child threads cannot run UI logic
             if(nativeMethodId == "os.showMessageBox" ||
                 regex_match(nativeMethodId, regex("^window.*")) ||
-                regex_match(nativeMethodId, regex("^computer.*")) ||
+                (regex_match(nativeMethodId, regex("^computer.*")) && nativeMethodId != "computer.getCPUUsage") ||
                 nativeMethodId == "os.setTray") {
                 dispatch_sync(dispatch_get_main_queue(), ^{
                     apiOutput = (*nativeMethod)(request.data);

--- a/spec/computer.spec.js
+++ b/spec/computer.spec.js
@@ -240,5 +240,41 @@ describe('computer.spec: computer namespace tests', () => {
             assert.ok(key === "a" || key === "skipped", "Expected 'a' or skipped depending on platform");
         });
     });
+    describe('computer.getCPUUsage', () => {
+        it('returns CPU usage object with correct types', async function() {
+            runner.run(`
+                let cpuUsage;
+                try {
+                    cpuUsage = await Neutralino.computer.getCPUUsage();
+                } catch(e) {
+                    await __close("skipped");
+                    return;
+                }
+                await __close(JSON.stringify(cpuUsage));
+            `);
+            let output = runner.getOutput();
+            if(output === 'skipped' || output === 'NL_SP_MAXTIMT' || output === '') return;
+            let cpuUsage = JSON.parse(output);
+            assert.ok(typeof cpuUsage == 'object');
+            assert.ok(typeof cpuUsage.usage == 'number');
+        });
 
+        it('returns valid CPU usage range', async function() {
+            runner.run(`
+                let cpuUsage;
+                try {
+                    cpuUsage = await Neutralino.computer.getCPUUsage();
+                } catch(e) {
+                    await __close("skipped");
+                    return;
+                }
+                await __close(JSON.stringify(cpuUsage));
+            `);
+            let output = runner.getOutput();
+            if(output === 'skipped' || output === 'NL_SP_MAXTIMT' || output === '') return;
+            let cpuUsage = JSON.parse(output);
+            assert.ok(cpuUsage.usage >= 0 && cpuUsage.usage <= 100,
+                'CPU usage should be between 0 and 100');
+        });
+    });
 });


### PR DESCRIPTION
Adds a new getCPUUsage().
### Changes
- `api/computer/computer.cpp` — added `getCPUUsage()` implementation for all 3 platforms.
- `api/computer/computer.h` — added `getCPUUsage()` declaration to the controllers namespace.
- `spec/computer.spec.js` — added 2 new spec tests covering type checking and valid range validation (0–100).
- `server/router.cpp` — added `{"computer.getCPUUsage", &computer::controllers::getCPUUsage}` to methodMap; excluded from macOS main queue `dispatch_sync` to avoid deadlock with `usleep`.
### Returns
`usage`: current system-wide CPU usage percentage (0.0–100.0), or -1.0 if unavailable
### Test
Ran full test using `npm test` command
<img width="718" height="322" alt="Screenshot 2026-03-13 125149" src="https://github.com/user-attachments/assets/83bbc1e9-e038-428a-bc07-e177db26f9dc" />
all test cases of specs passing 