### PR TITLE
fix(linux): prevent Gdk-CRITICAL gdk-monitor-get-workarea assertion on missing monitor data

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -157,10 +157,14 @@ pair<int, int> __getCenterPos(bool useConfigSizes = false) {
         height = opt.height;
     }
     #if defined(__linux__) || defined(__FreeBSD__)
-    GdkRectangle screen;
-    gdk_monitor_get_workarea(gdk_display_get_primary_monitor(gdk_display_get_default()), &screen);
-    x = (screen.width - width) / 2;
-    y = (screen.height - height) / 2;
+    GdkRectangle screen = {0,0,0,0};
+    if(GdkDisplay *display = gdk_display_get_default()){
+        GdkMonitor *monitor =gdk_display_get_primary_monitor(display);
+        if(!monitor) monitor = gdk_display_get_monitor(display, 0);
+        if(monitor) gdk_monitor_get_workarea(monitor, &screen);
+    }
+    x = screen.width> 0 ? (screen.width - width) / 2 : 0;
+    y = screen.height> 0 ? (screen.height - height) /2 : 0;
     #elif defined(__APPLE__)
     auto displayId = CGMainDisplayID();
     x = (CGDisplayPixelsWide(displayId) - width) / 2;

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -157,14 +157,19 @@ pair<int, int> __getCenterPos(bool useConfigSizes = false) {
         height = opt.height;
     }
     #if defined(__linux__) || defined(__FreeBSD__)
-    GdkRectangle screen = {0,0,0,0};
-    if(GdkDisplay *display = gdk_display_get_default()){
-        GdkMonitor *monitor =gdk_display_get_primary_monitor(display);
-        if(!monitor) monitor = gdk_display_get_monitor(display, 0);
-        if(monitor) gdk_monitor_get_workarea(monitor, &screen);
+    GdkRectangle screen = {0};
+	GdkDisplay *display = gdk_display_get_default()
+    if(display){
+        GdkMonitor *monitor = gdk_display_get_primary_monitor(display);
+        if(!monitor) {
+			monitor = gdk_display_get_monitor(display, 0);
+		}
+        if(monitor) {
+			gdk_monitor_get_workarea(monitor, &screen);
+		}
     }
-    x = screen.width> 0 ? (screen.width - width) / 2 : 0;
-    y = screen.height> 0 ? (screen.height - height) /2 : 0;
+    x = (screen.width - width) / 2;
+    y = (screen.height - height) / 2;
     #elif defined(__APPLE__)
     auto displayId = CGMainDisplayID();
     x = (CGDisplayPixelsWide(displayId) - width) / 2;

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -158,7 +158,7 @@ pair<int, int> __getCenterPos(bool useConfigSizes = false) {
     }
     #if defined(__linux__) || defined(__FreeBSD__)
     GdkRectangle screen = {0};
-	GdkDisplay *display = gdk_display_get_default()
+	GdkDisplay *display = gdk_display_get_default();
     if(display){
         GdkMonitor *monitor = gdk_display_get_primary_monitor(display);
         if(!monitor) {


### PR DESCRIPTION
## Description
This PR fixes a Gdk-CRITICAL assertion error on Linux that occurs when the framework attempts to center the window in environments where a primary monitor is not accessible 

## Changes proposed
 - Added null pointer checks for  **GdkDisplay**  and **GdkMonitor** objects in window centering logic.
 - Added fallback to default window coordinates to (0,0) if screen dimensions cannot be retrieved.

## How to test it

**Steps to Reproduce:** 
- Build the Linux Library from the main branch.
- Run the binary in a standard Ubuntu terminal: `./bin/neutralino-linux_x64 --load-dir-res`
- observer the **Gdk-Critical**  warning in the terminal.

**Output of the Warning:**
```
Gdk-CRITICAL **: 14:28:17.432: gdk_monitor_get_workarea: assertion 'GDK_IS_MONITOR (monitor)' failed
```

**After the fix**
The assertion is no longer triggered.

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.