### PR TITLE
docs: fix typo in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-Everyone can help Neutralinojs become better! You can contribute the project by writing code, reporting bugs, submitting feature requests, and improving the documentaion. Get started with [this guide](https://neutralino.js.org/docs/contributing/framework-developer-guide) if you are going to contribute by code.
+Everyone can help Neutralinojs become better! You can contribute the project by writing code, reporting bugs, submitting feature requests, and improving the documentation. Get started with [this guide](https://neutralino.js.org/docs/contributing/framework-developer-guide) if you are going to contribute by code.
 
 We respect all contributors. Please interact with the community according to our [code of conduct](CODE_OF_CONDUCT.md). Thank you.


### PR DESCRIPTION
## Description
Fix a spelling mistake in the CONTRIBUTING.md file.

## Changes proposed
 - Corrected a typo in CONTRIBUTING.md by changing "documentaion" to "documentation".

## How to test it
 - Open the CONTRIBUTING.md file.
 - Navigate to line 3.
 - Confirm that the word is spelled as "documentation".

## Next steps
None.

## Deploy notes
None.