### PR TITLE
fix: correct typo in NE_CO_UNLTOMG error message ("grabbinng" → "grabbing")

### DIFF
--- a/errors.cpp
+++ b/errors.cpp
@@ -91,7 +91,7 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_OS_INVKNPT: return "Invalid platform path name: %1";
         // computer
         case errors::NE_CO_UNLTOSC: return "Unable to set mouse cursor";
-        case errors::NE_CO_UNLTOMG: return "Unable to set mouse grabbinng";
+        case errors::NE_CO_UNLTOMG: return "Unable to set mouse grabbing";
         // extensions
         case errors::NE_EX_EXTNOTC: return "%1 is not connected yet";
         // filesystem


### PR DESCRIPTION
 ```
     ## Summary
     Fixes a typo in the error message for the `NE_CO_UNLTOMG` error code in `errors.cpp`.

     ### Change
     - **File**: `errors.cpp` line 94
     - **Before**: `"Unable to set mouse grabbinng"` (double 'n')
     - **After**: `"Unable to set mouse grabbing"` (correct spelling)

     ### Related Issue
     Closes #1641

     This is a one-character fix to correct the spelling of "grabbing" in the error message returned when the framework is unable to set mouse grabbing.
     ```