### PR TITLE
fix: guard stoi() calls to prevent crashes on invalid inputs

### DIFF
--- a/resources.cpp
+++ b/resources.cpp
@@ -63,7 +63,18 @@ fs::FileReaderResult __getFileFromBundle(const string &filename) {
             return fileReaderResult;
         }
         unsigned long size = p.first;
-        unsigned long uOffset = stoi(p.second);
+        unsigned long uOffset = 0;
+        try {
+            uOffset = stoi(p.second);
+        }
+        catch(const exception& e) {
+            debug::log(debug::LogTypeError,
+                "Invalid resource offset in bundle for file: " + filename +
+                ". Value: \"" + p.second + "\"");
+            fileReaderResult.status = errors::NE_RS_TREEGER;
+            asarArchive.close();
+            return fileReaderResult;
+        }
 
         vector<char>fileBuf ( size );
         asarArchive.seekg(asarHeaderSize + uOffset);
@@ -91,7 +102,17 @@ fs::FileReaderResult __getFileFromEmbedded(const string &filename) {
 
         const unsigned char* bytes = (const unsigned char*)resource_ptr;
         unsigned long size = p.first;
-        unsigned long uOffset = stoi(p.second);
+        unsigned long uOffset = 0;
+        try {
+            uOffset = stoi(p.second);
+        }
+        catch(const exception& e) {
+            debug::log(debug::LogTypeError,
+                "Invalid resource offset in embedded binary for file: " + filename +
+                ". Value: \"" + p.second + "\"");
+            fileReaderResult.status = errors::NE_RS_TREEGER;
+            return fileReaderResult;
+        }
 
         vector<char>fileBuf ( size );
         for (size_t i = asarHeaderSize + uOffset; i < asarHeaderSize + uOffset + size; i++) {

--- a/settings.cpp
+++ b/settings.cpp
@@ -92,7 +92,15 @@ bool init() {
 
         // String to actual types
         if(cfgOverride.convertTo == "int") {
-            patch["value"] = stoi(cfgOverride.value);
+            try {
+                patch["value"] = stoi(cfgOverride.value);
+            }
+            catch(const exception& e) {
+                debug::log(debug::LogTypeError,
+                    "Invalid integer value for config key '" + cfgOverride.key +
+                    "': \"" + cfgOverride.value + "\". Skipping override.");
+                continue;
+            }
         }
         else if(cfgOverride.convertTo == "bool") {
             patch["value"] = cfgOverride.value == "true";


### PR DESCRIPTION
## Summary
Fixes 3 unguarded `stoi()` calls in [settings.cpp](cci:7://file:///d:/openSource/neutralinojs/settings.cpp:0:0-0:0) and [resources.cpp](cci:7://file:///d:/openSource/neutralinojs/resources.cpp:0:0-0:0) that crash
the process on invalid input (`std::invalid_argument` / `std::out_of_range`).

## Changes
- **[settings.cpp](cci:7://file:///d:/openSource/neutralinojs/settings.cpp:0:0-0:0)**: `stoi(cfgOverride.value)` — CLI args like `--port=abc` now log an error and skip the override instead of crashing
- **[resources.cpp](cci:7://file:///d:/openSource/neutralinojs/resources.cpp:0:0-0:0) ([__getFileFromBundle](cci:1://file:///d:/openSource/neutralinojs/resources.cpp:55:0-89:1))**: `stoi(p.second)` for malformed `.asar` offset — closes archive handle and returns `NE_RS_TREEGER`
- **[resources.cpp](cci:7://file:///d:/openSource/neutralinojs/resources.cpp:0:0-0:0) ([__getFileFromEmbedded](cci:1://file:///d:/openSource/neutralinojs/resources.cpp:91:0-128:1))**: `stoi(p.second)` for malformed embedded offset — returns `NE_RS_TREEGER`

## Screenshots

**Before fix — process crashes:**
<img width="2294" height="197" alt="image" src="https://github.com/user-attachments/assets/b4c7d708-bb3a-483a-973e-a791b8fe3352" />

**After fix — graceful error log, no crash:**
<img width="2297" height="260" alt="image" src="https://github.com/user-attachments/assets/65f53cb0-ae21-454d-a67c-02a117fbc343" />

Closes #1583
