### PR TITLE
fix: prevent memory leak and invalid state when createWatcher() fails

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -256,6 +256,10 @@ long createWatcher(const string &path) {
 
     __WatcherListener* listener = new __WatcherListener();
     efsw::WatchID watcherId = fileWatcher->addWatch(path, listener, true);
+    if(watcherId < 0) {
+        delete listener;
+        return (long)watcherId;
+    }
     watchListeners[watcherId] = make_pair(listener, path);
     fileWatcher->watch();
     return (long)watcherId;


### PR DESCRIPTION
If `efsw::addWatch()` returns a negative ID (invalid path, inaccessible path, etc.), the listener is now deleted and returned immediately without storing in `watchListeners`, preventing memory leaks and inconsistent watcher state.

Fixes: #1600

## Description
When `efsw::addWatch()` fails it returns a negative `WatchID`. Previously this negative ID and its allocated listener were unconditionally stored in `watchListeners`, causing memory leaks and leaving the watcher map in an inconsistent state where [removeWatcher()](cci:1://file:///d:/openSource/neutralinojs/api/fs/fs.cpp:267:0-276:1) would find the bad ID but fail to clean it up properly.

## Changes proposed

- Check `addWatch()` return value before registering the listener in `watchListeners`
- If negative, `delete listener` immediately and return the error code — nothing is stored

## How to test it

- Call `Neutralino.filesystem.createWatcher("/path/that/does/not/exist")`
- Observe that an error is returned (`NE_FS_UNLCWAT`) and no watcher ID is registered
- Call `Neutralino.filesystem.getWatchers()` and confirm the invalid path does not appear in the list

## Next steps

None.

## Deploy notes

None.