### PR TITLE
fix: respect Windows display zoom for window size and position

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -166,10 +166,13 @@ pair<int, int> __getCenterPos(bool useConfigSizes = false) {
     x = (CGDisplayPixelsWide(displayId) - width) / 2;
     y = (CGDisplayPixelsHigh(displayId) - height) / 2;
     #elif defined(_WIN32)
-	RECT screen;
-	GetWindowRect(GetDesktopWindow(), &screen);
-    x = ((screen.right - screen.left) - width) / 2;
-    y = ((screen.bottom - screen.top) - height) / 2;
+    // Use the primary monitor's work area (excludes taskbar) for correct
+    // centering at any DPI zoom level.
+    HMONITOR hMon = MonitorFromPoint({0, 0}, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO mi = { sizeof(MONITORINFO) };
+    GetMonitorInfo(hMon, &mi);
+    x = ((mi.rcWork.right  - mi.rcWork.left) - width)  / 2 + mi.rcWork.left;
+    y = ((mi.rcWork.bottom - mi.rcWork.top)  - height) / 2 + mi.rcWork.top;
     #endif
     return make_pair(x, y);
 }
@@ -233,7 +236,12 @@ bool __getEncoderClsid(const WCHAR *format, CLSID *pClsid) {
 
 double __getScaleFactor() {
 	#if defined(_WIN32)
-    return GetDpiForSystem() / 96.0;
+    // Use per-window DPI when available (correct on multi-monitor / mixed zoom setups).
+    // Fall back to system DPI only before the window handle has been created.
+    UINT dpi = (windowHandle != nullptr)
+        ? GetDpiForWindow(windowHandle)
+        : GetDpiForSystem();
+    return dpi / 96.0;
 
 	#elif defined(__APPLE__)
     id screen = ((id (*)(id, SEL))objc_msgSend)(
@@ -617,11 +625,22 @@ bool __createWindow() {
 
     int width = windowProps.sizeOptions.width;
     int height = windowProps.sizeOptions.height;
-    if(windowProps.useLogicalPixels) {
+    #if defined(_WIN32)
+    // On Windows, neutralino.config.json dimensions are logical pixels but
+    // WebView2/Win32 always works in physical pixels. Always scale here so the
+    // window respects the display zoom level (e.g. 125%, 150%).
+    {
         double scale = __getScaleFactor();
-        if(width > 0)  width  = (int)(width  * scale);
+        if(width  > 0) width  = (int)(width  * scale);
         if(height > 0) height = (int)(height * scale);
     }
+    #else
+    if(windowProps.useLogicalPixels) {
+        double scale = __getScaleFactor();
+        if(width  > 0) width  = (int)(width  * scale);
+        if(height > 0) height = (int)(height * scale);
+    }
+    #endif
 
     nativeWindow->set_size(
     width,
@@ -984,11 +1003,19 @@ window::SizeOptions getSize() {
         height = winPos.bottom - winPos.top;
     }
     #endif
+    #if defined(_WIN32)
+    {
+        double scale = __getScaleFactor();
+        width = (int)(width / scale);
+        height = (int)(height / scale);
+    }
+    #else
     if(windowProps.useLogicalPixels) {
         double scale = __getScaleFactor();
         width = (int)(width / scale);
         height = (int)(height / scale);
    }
+   #endif
 
     windowProps.sizeOptions.width = width;
     windowProps.sizeOptions.height = height;
@@ -1491,11 +1518,19 @@ json setSize(const json &input) {
     int width = windowProps.sizeOptions.width;
     int height = windowProps.sizeOptions.height;
 
+    #if defined(_WIN32)
+    {
+        double scale = __getScaleFactor();
+        if(width > 0)  width  = (int)(width  * scale);
+        if(height > 0) height = (int)(height * scale);
+    }
+    #else
     if(windowProps.useLogicalPixels) {
         double scale = __getScaleFactor();
         if(width > 0)  width  = (int)(width  * scale);
         if(height > 0) height = (int)(height * scale);
     }
+    #endif
 
     nativeWindow->set_size(
         width,

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -954,6 +954,8 @@ public:
         std::wstring wargs = str2wstr(args);
         SetEnvironmentVariableW(L"WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", wargs.c_str());
     }
+    // Set DPI awareness before window creation so CreateWindow uses physical pixels
+    setDpi();
     if (window == nullptr) {
       HINSTANCE hInstance = GetModuleHandle(nullptr);
       HICON icon = (HICON)LoadImage(
@@ -1084,8 +1086,6 @@ public:
     } else {
       m_window = *(static_cast<HWND *>(window));
     }
-
-    setDpi();
 
     if (transparent) {
       SetWindowLong(m_window, GWL_EXSTYLE, GetWindowLong(m_window, GWL_EXSTYLE) | WS_EX_LAYERED);
@@ -1222,7 +1222,7 @@ private:
       GetProcAddress(user32, "SetProcessDpiAwarenessContext"));
     if (func_win10) {
         // Windows 10+
-        func_win10(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+        func_win10(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
     }
   }
 


### PR DESCRIPTION
On Windows with display scaling (125%, 150%, etc.), the window size set in `neutralino.config.json` was ignored because the config values (logical pixels) were passed directly to Win32/WebView2, which expects physical pixels. This caused the window to render at the wrong physical size. Additionally, `window.getSize()` and `window.setSize()` were not accounting for DPI scaling correctly.

Fixes: #1637

## Description
This PR fixes the window sizing and centering issues on Windows machines that use display scaling/zoom:
- Ensures Win32 API receives coordinates and sizes in physical pixels while Neutralino config/APIs remain consistently in logical CSS pixels.
- Upgrades DPI awareness to evaluate per-monitor instead of system-wide, fixing setups with multiple monitors having mixed DPI zooming.
- Moves the DPI awareness initialization to happen *before* the window is created so the OS knows the application's DPI capabilities at creation time.

## Changes proposed

- **[webview.h](cci:7://file:///d:/openSource/neutralinojs/lib/webview/webview.h:0:0-0:0)**: 
  - Move [setDpi()](cci:1://file:///d:/openSource/neutralinojs/lib/webview/webview.h:1218:2-1226:3) call before `CreateWindow` so DPI awareness is active at window creation time.
  - Upgrade DPI awareness from `PER_MONITOR_AWARE` to `PER_MONITOR_AWARE_V2` for correct per-monitor DPI handling on Windows 10+.
- **[window.cpp](cci:7://file:///d:/openSource/neutralinojs/api/window/window.cpp:0:0-0:0)**: 
  - Update [__getScaleFactor()](cci:1://file:///d:/openSource/neutralinojs/api/window/window.cpp:236:0-259:1) to use `GetDpiForWindow()` instead of `GetDpiForSystem()` for accurate per-monitor DPI. 
  - In [__createWindow()](cci:1://file:///d:/openSource/neutralinojs/api/window/window.cpp:610:0-713:1), [getSize()](cci:1://file:///d:/openSource/neutralinojs/api/window/window.cpp:980:0-1022:1), and [setSize()](cci:1://file:///d:/openSource/neutralinojs/api/window/window.cpp:1513:0-1546:1), always convert config width/height between logical to physical pixels on Windows, regardless of the `useLogicalPixels` flag.
  - In [__getCenterPos()](cci:1://file:///d:/openSource/neutralinojs/api/window/window.cpp:146:0-177:1), replace `GetWindowRect(GetDesktopWindow())` with `MonitorFromPoint` + `GetMonitorInfo` using `rcWork` so centering works accurately on scaled screens and properly excludes the Windows taskbar.

## How to test it
1. Set Windows display scaling to 125% or 150% (Settings → Display → Scale).
2. Set a specific width and height in `neutralino.config.json` (e.g., `"width": 800, "height": 600`).
3. Run `neu run`.
4. The window should open at the exact correct size, matching the configured logical dimensions, and perfectly centered on the screen (excluding the taskbar).
5. Calling `Neutralino.window.getSize()` should return the logical dimensions (e.g., 800x600), not the raw physical pixels.

## Next steps
None.

## Deploy notes
None.
