### PR TITLE
Validate defaultPath directory before opening the save dialog

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -534,6 +534,11 @@ json showSaveDialog(const json &input) {
     if(helpers::hasField(input, "defaultPath")) {
         defaultPath = input["defaultPath"].get<string>();
         defaultPath = helpers::unNormalizePath(defaultPath);
+        filesystem::path parentDir = filesystem::path(defaultPath).parent_path();
+        if(!parentDir.empty() && !filesystem::exists(parentDir)) {
+            output["error"] = errors::makeErrorPayload(errors::NE_OS_INVDPATH, defaultPath);
+            return output;
+        }
     }
 
     string selectedEntry = pfd::save_file(title, defaultPath, filters, option).result();

--- a/errors.cpp
+++ b/errors.cpp
@@ -25,6 +25,7 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_OS_INVMSGA: return "NE_OS_INVMSGA";
         case errors::NE_OS_TRAYIER: return "NE_OS_TRAYIER";
         case errors::NE_OS_INVKNPT: return "NE_OS_INVKNPT";
+        case errors::NE_OS_INVDPATH: return "NE_OS_INVDPATH";
         // computer
         case errors::NE_CO_UNLTOSC: return "NE_CO_UNLTOSC";
         case errors::NE_CO_UNLTOMG: return "NE_CO_UNLTOMG";
@@ -89,6 +90,7 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_OS_INVMSGA: return "Invalid message box style arguments: %1";
         case errors::NE_OS_TRAYIER: return "Unable to initialize the tray menu";
         case errors::NE_OS_INVKNPT: return "Invalid platform path name: %1";
+        case errors::NE_OS_INVDPATH: return "Invalid defaultPath directory for the file dialog: %1";
         // computer
         case errors::NE_CO_UNLTOSC: return "Unable to set mouse cursor";
         case errors::NE_CO_UNLTOMG: return "Unable to set mouse grabbinng";

--- a/errors.h
+++ b/errors.h
@@ -25,6 +25,7 @@ enum StatusCode {
     NE_OS_INVMSGA,
     NE_OS_TRAYIER,
     NE_OS_INVKNPT,
+    NE_OS_INVDPATH,
     // computer
     NE_CO_UNLTOSC,
     NE_CO_UNLTOMG,


### PR DESCRIPTION
showSaveDialog fails silently on Windows when defaultPath points to a 
directory that does not exist. This adds a check using std::filesystem 
before calling pfd::save_file, and returns a NE_OS_INVDPATH error if 
the parent directory is missing.

To test: call Neutralino.os.showSaveDialog with a defaultPath whose 
parent folder does not exist and confirm an error is returned instead 
of silent failure.