### PR TITLE
refactor: remove duplicate #include statements

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -2,7 +2,6 @@
 #include <fstream>
 #include <stdlib.h>
 #include <cstdio>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -16,7 +15,6 @@
 #include <atomic>
 #include <climits>
 
-#include "resources.h"
 #include "lib/tinyprocess/process.hpp"
 #include "lib/platformfolders/platform_folders.h"
 #include "lib/filedialogs/portable-file-dialogs.h"

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -12,7 +12,6 @@
 #include "lib/json/json.hpp"
 
 #if defined(_WIN32)
-#include <string>
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
## Description

Noticed a few duplicate `#include` directives while reading through the source.

## Changes proposed

- `helpers.cpp`: removed duplicate `#include <string>` inside the `_WIN32` block (already included unconditionally at the top of the file)
- `api/os/os.cpp`: removed duplicate `#include <iostream>` (lines 1 and 5 were identical)
- `api/os/os.cpp`: removed duplicate `#include "resources.h"` (included at both line 19 and line 49)

## How to test it

- Build the project and confirm it compiles without errors

## Next steps

None.

## Deploy notes

None.