### PR TITLE
fix: add mutex lock to updateSpawnedProcess to prevent use-after-free

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -216,6 +216,7 @@ pair<int, int> spawnProcess(string command, const os::ChildProcessOptions &optio
 }
 
 bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt) {
+    lock_guard<mutex> guard(spawnedProcessesLock);
     if(spawnedProcesses.find(evt.id) == spawnedProcesses.end()) {
         return false;
     }


### PR DESCRIPTION
## Problem

`updateSpawnedProcess()` reads from the `spawnedProcesses` map and dereferences process pointers without holding `spawnedProcessesLock`. The cleanup thread spawned by `spawnProcess()` modifies the same map (`erase` + `delete`) under the lock, creating a TOCTOU race condition:

1. Thread A calls `updateSpawnedProcess`, finds the process, gets the raw pointer
2. Thread B (cleanup) acquires the lock, erases the entry, deletes the pointer
3. Thread A dereferences a dangling pointer

## Fix

Add `lock_guard<mutex> guard(spawnedProcessesLock)` at the top of `updateSpawnedProcess`, matching the existing pattern in `spawnProcess` (line 163) and `getSpawnedProcesses` (line 398).

The lock scope covers the full function body so the process entry and pointer remain valid for the duration of the operation. No deadlock risk since TinyProcessLib's `kill()`, `write()`, and `close_stdin()` don't acquire this lock internally.

Closes #1622