### PR TITLE
Mount semantics extension #1542

### DIFF
--- a/server/router.cpp
+++ b/server/router.cpp
@@ -287,15 +287,14 @@ map<string, string> getMounts() {
 
 router::Response getAsset(string path, const string &prependData) {
     router::Response response;
-    vector<string> split = helpers::split(path, '.');
-
-    if(split.size() < 2) {
-        if(path.back() != '/')
-            path += "/";
-        return getAsset(path + "index.html", prependData);
+    string extension = "";
+    size_t slashPos = path.find_last_of('/');
+    string fileName = slashPos == string::npos ? path : path.substr(slashPos + 1);
+    bool hasExtension = !fileName.empty() && fileName.find('.') != string::npos;
+    if(hasExtension) {
+        size_t dotPos = fileName.find_last_of('.');
+        extension = fileName.substr(dotPos + 1);
     }
-
-    string extension = split[split.size() - 1];
     map<string, string> mimeTypes = {
         // Plain text files
         {"css", "text/css"},
@@ -370,6 +369,16 @@ router::Response getAsset(string path, const string &prependData) {
 
     if(!foundMountedPath) {
         fileReaderResult = resources::getFile(path);
+    }
+
+    // If the requested path has no extension and cannot be resolved,
+    // treat it as a directory request and fallback to /index.html.
+    if(fileReaderResult.status != errors::NE_ST_OK && !hasExtension) {
+        string indexPath = path;
+        if(indexPath.back() != '/') {
+            indexPath += "/";
+        }
+        return getAsset(indexPath + "index.html", prependData);
     }
     
     if(fileReaderResult.status != errors::NE_ST_OK) {

--- a/spec/server.spec.js
+++ b/spec/server.spec.js
@@ -71,6 +71,28 @@ describe('server.spec: server namespace tests', () => {
             assert.ok(typeof output === 'object', 'Expected output is an object');
             assert.ok(output.fetch1 === 200, 'The file request to a mounted directory succeeds');
         });
+
+        it('serves mounted files with no extension', async () => {
+            runner.run(`
+                const response = {};
+                const targetPath = NL_PATH + '/.tmp/test-mount-noext';
+                await Neutralino.filesystem.createDirectory(targetPath);
+                await Neutralino.filesystem.writeFile(targetPath + '/Beast', 'Hello');
+
+                await Neutralino.server.mount('/project/cards', targetPath);
+
+                const fileResponse = await fetch('/project/cards/Beast');
+                response.status = fileResponse.status;
+                response.body = await fileResponse.text();
+
+                await Neutralino.server.unmount('/project/cards');
+                await __close(JSON.stringify(response));
+            `);
+            const output = JSON.parse(runner.getOutput());
+            assert.ok(typeof output === 'object', 'Expected output is an object');
+            assert.ok(output.status === 200, 'Expected extensionless mounted file request to succeed');
+            assert.ok(output.body === 'Hello', 'Expected extensionless file content to be served correctly');
+        });
     });
 
 });


### PR DESCRIPTION
This PR fixes issue #1542 by correcting mount path resolution for extensionless files.

When a mounted file path has no dot in its filename (for example /project/cards/Beast), the server now tries to serve that file directly first. It only falls back to /index.html if direct resolution fails, preserving existing directory index behavior.

## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->
A fix was applied in router asset resolution so extensionless files are not incorrectly assumed to be directories.

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than neccessary.
-->

##Files Changed

[router.cpp](vscode-file://vscode-app/c:/Users/ysaty/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[server.spec.js](vscode-file://vscode-app/c:/Users/ysaty/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Change 1: Updated getAsset logic to attempt direct file read first for extensionless paths.

Change 2: Added fallback to /index.html only after extensionless direct read failure.

Change 3: Added a server.mount regression test for extensionless file serving.

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->
a.In spec folder: npx mocha [server.spec.js](vscode-file://vscode-app/c:/Users/ysaty/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
b.Verify new case:
1.Mount a folder containing file named Beast (no extension)
2.Fetch /project/cards/Beast
3.Expect HTTP 200 and correct body content
 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->
1.No schema/config/runtime migration required.
2.Deploy by releasing a new Neutralino server binary built from this commit.
3.If packaging app resources separately, no extra resource deployment is needed for this fix (code change is in core server + test only).
4.Rollback plan: redeploy previous binary version if needed.
