### PR TITLE
Add default case to error status switch in errors.cpp

### DIFF
--- a/errors.cpp
+++ b/errors.cpp
@@ -69,6 +69,7 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_CF_UNBPRCF: return "NE_CF_UNBPRCF";
         case errors::NE_CF_UNSUPMD: return "NE_CF_UNSUPMD";
         case errors::NE_CF_UNBLWCF: return "NE_CF_UNBLWCF";
+		default: return "NE_UNKNOWN";
     }
     return "NE_ST_NOTOK";
 }


### PR DESCRIPTION
**Description**
The __getStatusCodeString() function in errors.cpp uses a switch statement to map StatusCode enum values to their string representations, but has no default: case. If an unrecognized or future StatusCode is passed, the function returns an empty string silently, which can make debugging harder.
This PR adds a default: case that returns a clearly identifiable fallback string.
**Changes proposed**

Added a default: return "NE_UNKNOWN"; case to the switch statement in __getStatusCodeString() in errors.cpp

**How to test it**

Build the project normally and verify it compiles without warnings
Pass an out-of-range or cast integer as a StatusCode to __getStatusCodeString() and confirm it returns "NE_UNKNOWN" instead of an empty string
