### PR TITLE
Replace sleep interval 20000ms with named constant in __wait()

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
 #define NEU_APP_LOG_FILE "/neutralinojs.log"
 #define NEU_APP_LOG_FORMAT "%level %datetime %msg %loc %user@%host"
 #define ELPP_THREAD_SAFE
+#define NEU_APP_WAIT_INTERVAL_MS 20000
 
 INITIALIZE_EASYLOGGINGPP
 
@@ -36,7 +37,7 @@ string navigationUrl = "";
 
 void __wait() {
     while(true) {
-        this_thread::sleep_for(20000ms);
+        this_thread::sleep_for(chrono::milliseconds(NEU_APP_WAIT_INTERVAL_MS));
     }
 }
 
@@ -172,7 +173,7 @@ void __initExtra() {
 #if defined(_WIN32)
 void __attachConsole() {
     FILE* fp;
-    if(AttachConsole(ATTACH_PARENT_PROCESS)) { 
+    if(AttachConsole(ATTACH_PARENT_PROCESS)) {
         freopen_s(&fp, "CONIN$", "r", stdin);
         freopen_s(&fp, "CONOUT$", "w", stdout);
         freopen_s(&fp, "CONOUT$", "w", stderr);

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <string>
 #include <thread>
+#include <chrono>
 #if defined(_WIN32)
 #include <winsock2.h>
 #include <websocketpp/error.hpp>


### PR DESCRIPTION
**Description**
The __wait() function in main.cpp uses a hardcoded number 20000ms as the sleep interval. Random numbers reduce code readability and make future changes harder to track. This PR replaces it with a named constant defined alongside the other app-level macros at the top of the file.

**Changes proposed**
Added #define NEU_APP_WAIT_INTERVAL_MS 20000 near the top of main.cpp alongside existing macro definitions
Replaced the inline 20000ms literal in __wait() with chrono::milliseconds(NEU_APP_WAIT_INTERVAL_MS)

**How to test it**
Build the project and verify it compiles without warnings or errors
Run the app in browser or cloud mode (both trigger __wait()) and confirm the app continues to behave normally