### PR TITLE
Fix virtualFileId collision when files are closed and reopened

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <mutex>
+#include <atomic>
 #include <iostream>
 #include <fstream>
 #include <regex>
@@ -41,6 +42,7 @@ using json = nlohmann::json;
 
 map<int, ifstream*> openedFiles;
 mutex openedFilesLock;
+atomic<int> nextVirtualFileId(0);
 efsw::FileWatcher* fileWatcher;
 map<efsw::WatchID, pair<efsw::FileWatchListener*, string>> watchListeners;
 mutex watcherLock;
@@ -195,7 +197,7 @@ bool writeFile(const fs::FileWriterOptions &fileWriterOptions) {
 }
 
 int openFile(const string &filename) {
-    int virtualFileId = openedFiles.size();
+     int virtualFileId = nextVirtualFileId++;
     ifstream *reader = new ifstream(CONVSTR(filename), ios::binary);
     if(!reader->is_open()) {
         delete reader;
@@ -355,12 +357,12 @@ fs::DirReaderResult readDirectory(const string &path, bool recursive) {
 string applyPathConstants(const string &path) {
     string newPath = regex_replace(path, regex("\\$\\{NL_PATH\\}"), settings::getAppPath());
 
-    vector<string> pathNames = {"data", "cache", "documents", 
+    vector<string> pathNames = {"data", "cache", "documents",
                     "pictures", "music", "video", "downloads",
                     "saveGames1", "saveGames2", "temp"};
     for(const string &pathName: pathNames) {
         string varSegment = pathName;
-        transform(varSegment.begin(), varSegment.end(), varSegment.begin(), ::toupper); 
+        transform(varSegment.begin(), varSegment.end(), varSegment.begin(), ::toupper);
         newPath = regex_replace(newPath, regex("\\$\\{NL_OS" + varSegment + "PATH\\}"), os::getPath(pathName));
     }
     return newPath;
@@ -788,7 +790,7 @@ json getRelativePath(const json &input) {
     if(helpers::hasField(input, "base")) {
         base = input["base"].get<string>();
     }
-    
+
     string relPath = FS_CONVWSTRN(filesystem::relative(CONVSTR(path), CONVSTR(base)));
     output["returnValue"] = relPath;
     output["success"] = true;
@@ -803,7 +805,7 @@ json getPathParts(const json &input) {
     }
     string path = input["path"].get<string>();
     auto pathObj = filesystem::path(CONVSTR(path));
-    
+
     json pathParts = {
         {"rootName", FS_CONVWSTRN(pathObj.root_name())},
         {"rootDirectory", FS_CONVWSTRN(pathObj.root_directory())},
@@ -826,14 +828,14 @@ json getPermissions(const json &input) {
         return output;
     }
     string path = input["path"].get<string>();
-    
+
     fs::FileStats fileStats = fs::getStats(path);
     if(fileStats.status != errors::NE_ST_OK) {
         output["error"] = errors::makeErrorPayload(fileStats.status, path);
         return output;
     }
     auto perms = filesystem::status(CONVSTR(path)).permissions();
-    
+
     json permissions = {
         {"all", filesystem::perms::all == (perms & filesystem::perms::all)},
         {"ownerAll", filesystem::perms::owner_all == (perms & filesystem::perms::owner_all)},
@@ -849,7 +851,7 @@ json getPermissions(const json &input) {
         {"othersWrite", filesystem::perms::none != (perms & filesystem::perms::others_write)},
         {"othersExec", filesystem::perms::none != (perms & filesystem::perms::others_exec)}
     };
-    
+
     output["returnValue"] = permissions;
     output["success"] = true;
     return output;
@@ -862,7 +864,7 @@ json setPermissions(const json &input) {
         return output;
     }
     string path = input["path"].get<string>();
-    
+
     error_code ec;
     filesystem::perms permissions = filesystem::perms::none;
     filesystem::perm_options permMode = filesystem::perm_options::replace;
@@ -900,10 +902,10 @@ json setPermissions(const json &input) {
         if(mode == "REPLACE") permMode = filesystem::perm_options::replace;
         if(mode == "REMOVE") permMode = filesystem::perm_options::remove;
     }
-    
+
     filesystem::permissions(CONVSTR(path), permissions, permMode, ec);
 
-    if(!ec) { 
+    if(!ec) {
         output["returnValue"] = permissions;
         output["success"] = true;
     }
@@ -925,7 +927,7 @@ json getJoinedPath(const json &input) {
     for(const string &path: paths) {
         joinedPath /= filesystem::path(CONVSTR(path));
     }
-    
+
     output["returnValue"] = FS_CONVWSTRN(filesystem::weakly_canonical(joinedPath));
     output["success"] = true;
     return output;
@@ -938,7 +940,7 @@ json getNormalizedPath(const json &input) {
         return output;
     }
     string path = input["path"].get<string>();
-    
+
     output["returnValue"] = helpers::normalizePath(path);
     output["success"] = true;
     return output;
@@ -951,7 +953,7 @@ json getUnnormalizedPath(const json &input) {
         return output;
     }
     string path = input["path"].get<string>();
-    
+
     output["returnValue"] = helpers::unNormalizePath(path);
     output["success"] = true;
     return output;


### PR DESCRIPTION
**Title:**
```
Fix virtualFileId collision in openFile when files are closed and reopened
```

**Description:**
```
## Description
The openFile() function in fs.cpp assigns virtualFileId using 
openedFiles.size(). This causes a collision bug: if files are 
opened and closed, the map shrinks, and the next opened file 
gets an ID that may already be in use by an existing open file. 
This silently overwrites the existing file handle, causing a 
memory leak and incorrect file reads.

This PR fixes it by using an atomic counter (nextVirtualFileId), 
following the same pattern already used for nextVirtualPid in os.cpp.

## Changes proposed
- Added atomic<int> nextVirtualFileId(0) as a global counter alongside other fs globals
- Replaced openedFiles.size() with nextVirtualFileId++ in openFile() for safe unique ID generation

## How to test it
- Open 3 files using Neutralino.filesystem.openFile()
- Close the file with ID 1
- Open a new file and confirm it receives a unique ID (not 2, which is already in use)
- Confirm the previously opened file with ID 2 is still readable and not overwritten

## Next steps
None.

## Deploy notes
None.