### PR TITLE
fix: allow hyphens in applicationId regex

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -129,7 +129,7 @@ json getConfig() {
 string getAppId() {
     if(!options["applicationId"].is_null()) {
         string appId = options["applicationId"].get<string>();
-        appId = regex_replace(appId, regex("[^\\w.]"), "");
+        appId = regex_replace(appId, regex("[^\\w.-]"), "");
         return regex_replace(appId, regex("[.]{2,}"), ".");
     }
     return "js.neutralino.framework";


### PR DESCRIPTION
Updates the `applicationId` regular expression parsing in `settings.cpp` to include hyphens (`-`). 

**Context:**
Previously, valid application identifiers containing hyphens (e.g., `com.my-app.demo`) were aggressively stripped during the regex replacement. Because the hyphen was missing from the allowed character class `[^\w.]`, the engine mutated the ID, causing downstream crashes. 

Adding the literal hyphen to the regex exclusion list `[^\w.-]` ensures the engine parses these valid IDs correctly without mutating them.

Resolves #144