### PR TITLE
feat: add "home" and "desktop" paths to os.getPath()

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -241,7 +241,7 @@ bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt) {
 }
 
 static string __getHomePath() {
-    #if defined(__linux__) || defined(__APPLE__)
+    #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         const char* home = getenv("HOME");
         if(getuid() != 0 && home)
             return string(home);

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -24,6 +24,7 @@
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 #include <unistd.h>
 #include <pwd.h>
+#include <sys/types.h>
 extern char **environ;
 #endif
 

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -23,6 +23,7 @@
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 #include <unistd.h>
+#include <pwd.h>
 extern char **environ;
 #endif
 
@@ -36,6 +37,7 @@ extern char **environ;
 #include <tchar.h>
 #include <gdiplus.h>
 #include <shlwapi.h>
+#include <shlobj.h>
 
 #pragma comment(lib, "Shell32.lib")
 #pragma comment(lib, "Gdiplus.lib")
@@ -238,6 +240,23 @@ bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt) {
     return true;
 }
 
+static string __getHomePath() {
+    #if defined(__linux__) || defined(__APPLE__)
+        const char* home = getenv("HOME");
+        if(getuid() != 0 && home)
+            return string(home);
+        return string(getpwuid(getuid())->pw_dir);
+    #elif defined(_WIN32)
+        PWSTR homePath = nullptr;
+        if(SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Profile, 0, nullptr, &homePath))) {
+            string path = FS_CONVWSTR(homePath);
+            CoTaskMemFree(homePath);
+            return path;
+        }
+    #endif
+    return "";
+}
+
 string getPath(const string &name) {
     string path = "";
     if(name == "config")
@@ -262,6 +281,10 @@ string getPath(const string &name) {
         path = sago::getSaveGamesFolder2();
     else if(name == "temp")
         path = FS_CONVWSTR(filesystem::temp_directory_path());
+    else if(name == "desktop")
+        path = sago::getDesktopFolder();
+    else if(name == "home")
+        path = __getHomePath();
     return helpers::normalizePath(path);
 }
 


### PR DESCRIPTION
## Description
Closes #1568

os.getPath() was missing two commonly needed paths. "desktop" was already available in the bundled sago library, but never wired up. "home" required a new private helper since sago does not expose it.

## Changes proposed
- Added "desktop" path using sago::getDesktopFolder()
- Added `home` path resolution:
  - Uses `$HOME` or `getpwuid()` on Unix systems
  - Uses `SHGetKnownFolderPath` on Windows
- Added null checks for `getpwuid()` to prevent potential crashes
- Added pwd.h header for Linux/macOS and shlobj.h for Windows

## How to test it
Run the following in any Neutralino app's dev console:

```
(async () => {
  console.log("home:", await Neutralino.os.getPath("home"));
  console.log("desktop:", await Neutralino.os.getPath("desktop"));
})();
```

Expected: correct home and desktop paths for the current user

## Next steps

None.

## Deploy notes

None.

Tested on Linux. Happy to make any changes based on your feedback.