### PR TITLE
Refactor :  fix variable shadowing in handlemessage function.

### DIFF
--- a/server/neuserver.cpp
+++ b/server/neuserver.cpp
@@ -179,12 +179,12 @@ void handleMessage(websocketpp::connection_hdl handler, websocketserver::message
         });
 
         try {
-            json nativeMessage;
-            nativeMessage["id"] = nativeResponse.id;
-            nativeMessage["method"] = nativeResponse.method;
-            nativeMessage["data"] = nativeResponse.data;
+            json responseMessage;
+            responseMessage["id"] = nativeResponse.id;
+            responseMessage["method"] = nativeResponse.method;
+            responseMessage["data"] = nativeResponse.data;
 
-            server->send(handler, helpers::jsonToString(nativeMessage), msg->get_opcode());
+            server->send(handler, helpers::jsonToString(responseMessage), msg->get_opcode());
         } catch (websocketpp::exception const & e) {
             debug::log(debug::LogTypeError, errors::makeErrorMsg(errors::NE_SR_UNBSEND));
         }
@@ -273,7 +273,7 @@ bool handleValidate(websocketpp::connection_hdl handler) {
 
 void broadcast(const json &message) {
     neuserver::broadcastToAllApps(message);
-    neuserver::broadcastToAllExtensions(message);
+    neuserver::broadcastToAllExtensions(message); 
 }
 
 bool sendToExtension(const string &extensionId, const json &message) {


### PR DESCRIPTION
"I have renamed the nested nativeMessage variable to responseMessage to resolve variable shadowing. Additionally, updated the server->send call to use the correct object. This improves code readability and prevents potential logic errors."

## Description
<!--
    This PR addresses a variable shadowing issue in the neuserver.cpp file within the handleMessage function. By renaming the inner nativeMessage variable to responseMessage, the code becomes clearer and potential logic conflicts are avoided.
-->

## Changes proposed
<!--
    Renamed nested json nativeMessage to json responseMessage in handleMessage.
Updated server->send call to use the newly named responseMessage object.
Fixed variable shadowing to improve code maintainability.
-->