### PR TITLE
feat(window): redirect external URLs to system browser

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -54,6 +54,7 @@
 #include "api/fs/fs.h"
 #include "api/debug/debug.h"
 #include "api/computer/computer.h"
+#include "api/os/os.h"
 
 using namespace std;
 using json = nlohmann::json;
@@ -634,6 +635,10 @@ bool __createWindow() {
 );
 
     nativeWindow->setEventHandler(&window::handlers::windowStateChange);
+
+    nativeWindow->setNewWindowHandler([](const std::string& url) {
+        os::open(url);
+    });
 
     if(windowProps.injectGlobals) 
         nativeWindow->init(settings::getGlobalVars() + "var NL_GINJECTED = true;");

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -320,7 +320,7 @@ public:
             const char* uri = webkit_uri_request_get_uri(request);
             if(uri) {
                 std::string uriStr(uri);
-                if(uriStr.find("http://localhost") != 0 && newWindowHandler) {
+                if(uriStr.find("http://localhost") != 0 && uriStr.find("http://127.0.0.1") != 0 &&newWindowHandler) {
                     newWindowHandler(uriStr);
                 }
             }
@@ -645,7 +645,7 @@ public:
             const char* uri = ((const char*(*)(id,SEL))objc_msgSend)(urlStr, "UTF8String"_sel);
             if(uri) {
                 std::string uriStr(uri);
-                if(uriStr.find("http://localhost") != 0 && newWindowHandler) {
+                if(uriStr.find("http://localhost") != 0 && uriStr.find("http://127.0.0.1") != 0 && newWindowHandler) {
                     newWindowHandler(uriStr);
                 }
             }
@@ -970,7 +970,7 @@ private:
                 args->get_Uri(&uri);
                 std::wstring ws(uri);
                 std::string url(ws.begin(), ws.end());
-                if(url.find("http://localhost") != 0 && newWindowHandler) {
+                if(url.find("http://localhost") != 0 && url.find("https://127.0.0.1") != 0 && newWindowHandler) {
                     newWindowHandler(url);
                 }
                 args->put_Handled(TRUE);

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -970,7 +970,7 @@ private:
                 args->get_Uri(&uri);
                 std::wstring ws(uri);
                 std::string url(ws.begin(), ws.end());
-                if(url.find("http://localhost") != 0 && url.find("https://127.0.0.1") != 0 && newWindowHandler) {
+                if(url.find("http://localhost") != 0 && url.find("http://127.0.0.1") != 0 && newWindowHandler) {
                     newWindowHandler(url);
                 }
                 args->put_Handled(TRUE);

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -73,6 +73,7 @@ using eventHandler_t = std::function<void(int)>;
 
 static eventHandler_t windowStateChange;
 static int processExitCode = 0;
+static std::function<void(const std::string&)> newWindowHandler;
 
 struct WindowMenuItem {
   std::string id;
@@ -107,6 +108,7 @@ struct WindowMenuItem {
 
 // webkit2gtk definitions
 using WebKitWebView = struct _WebKitWebView;
+using WebKitNavigationAction = struct _WebKitNavigationAction;
 using WebKitSettings = struct _WebKitSettings;
 using WebKitWebInspector = struct _WebKitWebInspector;
 using WebKitUserContentManager = struct _WebKitUserContentManager;
@@ -303,6 +305,29 @@ public:
     }
 
     gtk_widget_show_all(m_window);
+
+    g_signal_connect(G_OBJECT(m_webview), "create",
+    G_CALLBACK(+[](WebKitWebView*, WebKitNavigationAction* action,
+                   gpointer) -> GtkWidget* {
+        using get_request_fn = std::add_pointer<void*(void*)>::type;
+        using get_uri_fn = std::add_pointer<const char*(void*)>::type;
+
+        auto webkit_navigation_action_get_request = (get_request_fn)dlsym(dlib, "webkit_navigation_action_get_request");
+        auto webkit_uri_request_get_uri = (get_uri_fn)dlsym(dlib, "webkit_uri_request_get_uri");
+
+        if(webkit_navigation_action_get_request && webkit_uri_request_get_uri) {
+            void* request = webkit_navigation_action_get_request(action);
+            const char* uri = webkit_uri_request_get_uri(request);
+            if(uri) {
+                std::string uriStr(uri);
+                if(uriStr.find("http://localhost") != 0 && newWindowHandler) {
+                    newWindowHandler(uriStr);
+                }
+            }
+        }
+        return nullptr;
+    }),
+    nullptr);
   }
   void *window() { return (void *)m_window; }
   void *wv() { return (void *)m_webview; }
@@ -608,6 +633,27 @@ public:
                                           m_webview);
     ((void (*)(id, SEL, id))objc_msgSend)(m_window, "makeKeyAndOrderFront:"_sel,
                                           nullptr);
+
+    auto uicls = objc_allocateClassPair((Class)"NSResponder"_cls, "WebViewUIDelegate", 0);
+    class_addProtocol(uicls, objc_getProtocol("WKUIDelegate"));
+    class_addMethod(uicls,
+        "webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:"_sel,
+        (IMP)(+[](id, SEL, id, id, id action, id) -> id {
+            id request = ((id(*)(id,SEL))objc_msgSend)(action, "request"_sel);
+            id nsurl  = ((id(*)(id,SEL))objc_msgSend)(request, "URL"_sel);
+            id urlStr = ((id(*)(id,SEL))objc_msgSend)(nsurl, "absoluteString"_sel);
+            const char* uri = ((const char*(*)(id,SEL))objc_msgSend)(urlStr, "UTF8String"_sel);
+            if(uri) {
+                std::string uriStr(uri);
+                if(uriStr.find("http://localhost") != 0 && newWindowHandler) {
+                    newWindowHandler(uriStr);
+                }
+            }
+            return nullptr;
+        }), "@@:@@@@");
+    objc_registerClassPair(uicls);
+    auto uidelegate = ((id(*)(id,SEL))objc_msgSend)((id)uicls, "new"_sel);
+    ((void(*)(id,SEL,id))objc_msgSend)(m_webview, "setUIDelegate:"_sel, uidelegate);
   }
   ~cocoa_wkwebview_engine() { close(); }
   void *window() { return (void *)m_window; }
@@ -915,6 +961,22 @@ private:
       controller->get_CoreWebView2(&webview);
       webview->add_WebMessageReceived(this, &token);
       webview->add_PermissionRequested(this, &token);
+      
+      webview->add_NewWindowRequested(
+        Callback<ICoreWebView2NewWindowRequestedEventHandler>(
+            [](ICoreWebView2* sender,
+              ICoreWebView2NewWindowRequestedEventArgs* args) -> HRESULT {
+                LPWSTR uri;
+                args->get_Uri(&uri);
+                std::wstring ws(uri);
+                std::string url(ws.begin(), ws.end());
+                if(url.find("http://localhost") != 0 && newWindowHandler) {
+                    newWindowHandler(url);
+                }
+                args->put_Handled(TRUE);
+                CoTaskMemFree(uri);
+                return S_OK;
+            }).Get(), &token);
 
       m_cb(controller);
       return S_OK;
@@ -1267,6 +1329,10 @@ public:
 
   void setEventHandler(eventHandler_t handler) {
     windowStateChange = handler;
+  }
+  
+  void setNewWindowHandler(std::function<void(const std::string&)> handler) {
+    newWindowHandler = handler;
   }
 
   int get_init_code() {

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -795,6 +795,7 @@ using browser_engine = cocoa_wkwebview_engine;
 #include <codecvt>
 #include <stdlib.h>
 #include <windows.h>
+#include <wrl.h>
 
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "Shlwapi.lib")
@@ -813,6 +814,8 @@ using browser_engine = cocoa_wkwebview_engine;
 #define WM_WINDOW_PASS_MENU_REFS (WM_USER + 3)
 #define WM_WINDOW_DELETE_MENU_REFS (WM_USER + 4)
 #define ID_MENU_FIRST 20000
+
+using namespace Microsoft::WRL;
 
 namespace webview {
 

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -70,10 +70,11 @@
 namespace webview {
 using dispatch_fn_t = std::function<void()>;
 using eventHandler_t = std::function<void(int)>;
+using newWindowHandler_t = std::function<void(const std::string&)>;
 
 static eventHandler_t windowStateChange;
+static newWindowHandler_t newWindow;
 static int processExitCode = 0;
-static std::function<void(const std::string&)> newWindowHandler;
 
 struct WindowMenuItem {
   std::string id;
@@ -320,8 +321,8 @@ public:
             const char* uri = webkit_uri_request_get_uri(request);
             if(uri) {
                 std::string uriStr(uri);
-                if(uriStr.find("http://localhost") != 0 && uriStr.find("http://127.0.0.1") != 0 &&newWindowHandler) {
-                    newWindowHandler(uriStr);
+                if(uriStr.find("http://localhost") != 0 && uriStr.find("http://127.0.0.1") != 0 &&newWindow) {
+                    newWindow(uriStr);
                 }
             }
         }
@@ -645,8 +646,8 @@ public:
             const char* uri = ((const char*(*)(id,SEL))objc_msgSend)(urlStr, "UTF8String"_sel);
             if(uri) {
                 std::string uriStr(uri);
-                if(uriStr.find("http://localhost") != 0 && uriStr.find("http://127.0.0.1") != 0 && newWindowHandler) {
-                    newWindowHandler(uriStr);
+                if(uriStr.find("http://localhost") != 0 && uriStr.find("http://127.0.0.1") != 0 && newWindow) {
+                    newWindow(uriStr);
                 }
             }
             return nullptr;
@@ -970,8 +971,8 @@ private:
                 args->get_Uri(&uri);
                 std::wstring ws(uri);
                 std::string url(ws.begin(), ws.end());
-                if(url.find("http://localhost") != 0 && url.find("http://127.0.0.1") != 0 && newWindowHandler) {
-                    newWindowHandler(url);
+                if(url.find("http://localhost") != 0 && url.find("http://127.0.0.1") != 0 && newWindow) {
+                    newWindow(url);
                 }
                 args->put_Handled(TRUE);
                 CoTaskMemFree(uri);
@@ -1331,8 +1332,8 @@ public:
     windowStateChange = handler;
   }
   
-  void setNewWindowHandler(std::function<void(const std::string&)> handler) {
-    newWindowHandler = handler;
+  void setNewWindowHandler(newWindowHandler_t handler) {
+    newWindow = handler;
   }
 
   int get_init_code() {


### PR DESCRIPTION

## Description
Closes #1555

When a Neutralinojs app attempts to open an external link (via `window.open(url)` or `<a target="_blank">`), the webview has no handler for the new-window request. It is silently dropped on Windows, and on Linux/macOS, the behavior is undefined or trapped inside an internal webview.

## Changes proposed
- **lib/webview/webview.h:** Added a `newWindowHandler` callback and updated WebView2, WebKitGTK, and WKWebView backends to intercept "new window" requests and block the internal popup.
 - **api/window/window.cpp:** Attached the new handler to delegate the intercepted external URLs to `os::open()`. Internal URLs (`localhost` and `127.0.0.1`) are explicitly excluded to preserve app-internal navigation.

## How to test it
- Add a standard HTML link to a test app: 
```
<a href="https://example.com" target="_blank">Test HTML Link</a>
```
 - Add a JS button to a test app: 
 ```
<button onclick="window.open('https://example.com')">Test JS Link</button>
```
Expected: 
 - On click, it should successfully open in the OS's default web browser (e.g., Chrome, Firefox) rather than a secondary Neutralinojs window.
 - Standard internal navigation (localhost URLs) should work as expected within the app.

## Next steps

None.

## Deploy notes

None.

Tested on Linux. Happy to make any changes based on your feedback.