### PR TITLE
fix(res): prevent path traversal (CWE-22) in extractFile and extractDirectory

### DIFF
--- a/api/res/res.cpp
+++ b/api/res/res.cpp
@@ -175,14 +175,19 @@ json extractFile(const json &input) {
     string path = input["path"].get<string>();
     string destination = input["destination"].get<string>();
     
+    if (destination.find('\0') != std::string::npos) {
+        output["error"] = errors::makeErrorPayload(errors::NE_RS_FILEXTF, destination);
+        return output;
+    }
+
     error_code canonicalEc;
     auto resolvedDest = filesystem::weakly_canonical(filesystem::path(CONVSTR(destination)), canonicalEc);
-    auto basePath = filesystem::current_path(); 
+    auto basePath = filesystem::canonical(filesystem::current_path()); 
 
     auto mismatch = std::mismatch(basePath.begin(), basePath.end(), resolvedDest.begin(), resolvedDest.end());
     
     if(canonicalEc || mismatch.first != basePath.end()) {
-        output["error"] = errors::makeErrorPayload(errors::NE_RS_DIREXTF, destination);
+        output["error"] = errors::makeErrorPayload(errors::NE_RS_FILEXTF, destination);
         return output;
     }
     
@@ -224,9 +229,14 @@ json extractDirectory(const json &input) {
     string path = input["path"].get<string>();
     string destination = input["destination"].get<string>();
 
+    if (destination.find('\0') != std::string::npos) {
+        output["error"] = errors::makeErrorPayload(errors::NE_RS_DIREXTF, destination);
+        return output;
+    }
+
     error_code canonicalEc;
     auto resolvedDest = filesystem::weakly_canonical(filesystem::path(CONVSTR(destination)), canonicalEc);
-    auto basePath = filesystem::current_path(); 
+    auto basePath = filesystem::canonical(filesystem::current_path());
 
     auto mismatch = std::mismatch(basePath.begin(), basePath.end(), resolvedDest.begin(), resolvedDest.end());
     

--- a/api/res/res.cpp
+++ b/api/res/res.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <algorithm>
 
 #include "lib/json/json.hpp"
 #include "settings.h"
@@ -174,6 +175,17 @@ json extractFile(const json &input) {
     string path = input["path"].get<string>();
     string destination = input["destination"].get<string>();
     
+    error_code canonicalEc;
+    auto resolvedDest = filesystem::weakly_canonical(filesystem::path(CONVSTR(destination)), canonicalEc);
+    auto basePath = filesystem::current_path(); 
+
+    auto mismatch = std::mismatch(basePath.begin(), basePath.end(), resolvedDest.begin(), resolvedDest.end());
+    
+    if(canonicalEc || mismatch.first != basePath.end()) {
+        output["error"] = errors::makeErrorPayload(errors::NE_RS_DIREXTF, destination);
+        return output;
+    }
+    
     if(resources::isBundleMode() && resources::extractFile(path, destination)) {
         output["success"] = true;
     }
@@ -211,6 +223,17 @@ json extractDirectory(const json &input) {
     }
     string path = input["path"].get<string>();
     string destination = input["destination"].get<string>();
+
+    error_code canonicalEc;
+    auto resolvedDest = filesystem::weakly_canonical(filesystem::path(CONVSTR(destination)), canonicalEc);
+    auto basePath = filesystem::current_path(); 
+
+    auto mismatch = std::mismatch(basePath.begin(), basePath.end(), resolvedDest.begin(), resolvedDest.end());
+    
+    if(canonicalEc || mismatch.first != basePath.end()) {
+        output["error"] = errors::makeErrorPayload(errors::NE_RS_DIREXTF, destination);
+        return output;
+    }
 
     if(resources::isBundleMode() || resources::isEmbeddedMode()) {
         auto resPaths = __getFiles(path);


### PR DESCRIPTION
## Description
Closes #1595

This PR fixes a critical CWE-22 (Path Traversal) vulnerability in the resources.extractFile and resources.extractDirectory native APIs. Previously, a malicious client could pass a destination containing `../` sequences to escape the application's working directory.

This improves upon the approach in the original fix(#1596) by addressing additional attack vectors that the string-based mismatch check alone does not cover.

## Changes proposed
- Canonicalize both destination and basePath via weakly_canonical() and canonical() before comparison, correctly resolving symlinks and.. components. Raw current_path() is insufficient if the working directory itself contains symlinks.
- Use std::mismatch() on path iterators (not strings) for strictsandbox boundary enforcement.
- Add null byte guard (destination.find('\0')) before path processing.A path like `../../../etc/passwd\0.txt` truncates at the OS level and bypasses string-based checks.
- Return correct error codes per function: NE_RS_FILEXTF for extractFile, NE_RS_DIREXTF for extractDirectory.
## How to test it
- Start a Neutralino app with a JavaScript payload attempting to write outside the sandbox:

Path traversal via `../` sequences:
```
Neutralino.resources.extractDirectory('/', '../../../../../../../tmp/pwned_directory')
Neutralino.resources.extractFile('/index.html', '../../../../../../../tmp/pwned_file.txt')
```
Symlink escape:
```
ln -s /tmp/outside ./resources/evil_link
Neutralino.resources.extractFile('/index.html', 'evil_link/../../../tmp/pwned.txt')
```
Null byte injection:
```
Neutralino.resources.extractFile('/index.html', '../../../tmp/pwned\x00.txt')
```
Expected: All three should return an error payload(`NE_RS_DIREXTF` / `NE_RS_FILEXTF`). None should write outside the app's working directory. 

## Next steps

None.

## Deploy notes

None.

Tested on Linux. Happy to make any changes based on your feedback.