### PR TITLE
fix: handle stoi() exceptions and correct INVALID_HANDLE_VALUE misuse

### DIFF
--- a/lib/tinyprocess/process_win.cpp
+++ b/lib/tinyprocess/process_win.cpp
@@ -298,7 +298,7 @@ void Process::kill(bool /*force*/) noexcept {
   std::lock_guard<std::mutex> lock(close_mutex);
   if(data.id > 0 && !closed) {
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if(snapshot) {
+    if(snapshot != INVALID_HANDLE_VALUE) {
       PROCESSENTRY32 process;
       ZeroMemory(&process, sizeof(process));
       process.dwSize = sizeof(process);
@@ -325,7 +325,7 @@ void Process::kill(id_type id, bool /*force*/) noexcept {
     return;
 
   HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-  if(snapshot) {
+  if(snapshot != INVALID_HANDLE_VALUE) {
     PROCESSENTRY32 process;
     ZeroMemory(&process, sizeof(process));
     process.dwSize = sizeof(process);

--- a/resources.cpp
+++ b/resources.cpp
@@ -63,7 +63,16 @@ fs::FileReaderResult __getFileFromBundle(const string &filename) {
             return fileReaderResult;
         }
         unsigned long size = p.first;
-        unsigned long uOffset = stoi(p.second);
+        unsigned long uOffset;
+        try {
+            uOffset = stoi(p.second);
+        }
+        catch(const exception &e) {
+            debug::log(debug::LogTypeError, e.what());
+            fileReaderResult.status = errors::NE_RS_UNBLDRE;
+            asarArchive.close();
+            return fileReaderResult;
+        }
 
         vector<char>fileBuf ( size );
         asarArchive.seekg(asarHeaderSize + uOffset);
@@ -91,7 +100,15 @@ fs::FileReaderResult __getFileFromEmbedded(const string &filename) {
 
         const unsigned char* bytes = (const unsigned char*)resource_ptr;
         unsigned long size = p.first;
-        unsigned long uOffset = stoi(p.second);
+        unsigned long uOffset;
+        try {
+            uOffset = stoi(p.second);
+        }
+        catch(const exception &e) {
+            debug::log(debug::LogTypeError, e.what());
+            fileReaderResult.status = errors::NE_RS_UNBLDRE;
+            return fileReaderResult;
+        }
 
         vector<char>fileBuf ( size );
         for (size_t i = asarHeaderSize + uOffset; i < asarHeaderSize + uOffset + size; i++) {

--- a/settings.cpp
+++ b/settings.cpp
@@ -92,7 +92,13 @@ bool init() {
 
         // String to actual types
         if(cfgOverride.convertTo == "int") {
-            patch["value"] = stoi(cfgOverride.value);
+            try {
+                patch["value"] = stoi(cfgOverride.value);
+            }
+            catch(const exception &e) {
+                debug::log(debug::LogTypeError, e.what());
+                continue;
+            }
         }
         else if(cfgOverride.convertTo == "bool") {
             patch["value"] = cfgOverride.value == "true";


### PR DESCRIPTION
## Summary

This PR fixes two distinct crash/correctness bugs in the framework:

### 1. Unhandled `stoi()` exceptions (crash risk)

`std::stoi()` throws `std::invalid_argument` if the input string is not a
valid integer, and `std::out_of_range` if the value overflows. Three call
sites were unguarded:

| File | Context |
|---|---|
| `resources.cpp` (bundle path) | Parses the file offset string from the ASAR header |
| `resources.cpp` (embedded path) | Same, for postject-embedded resources |
| `settings.cpp` | Converts CLI config-override values typed as `"int"` |

Each is now wrapped in a `try/catch(const std::exception &e)` block.
On failure, `resources.cpp` returns the appropriate `NE_RS_UNBLDRE` error
status; `settings.cpp` logs the error and skips the malformed override via
`continue`.

### 2. `INVALID_HANDLE_VALUE` misuse in `process_win.cpp`

`CreateToolhelp32Snapshot()` signals failure by returning
`INVALID_HANDLE_VALUE` (`(HANDLE)(LONG_PTR)-1`), **not** `NULL`.
The previous check `if(snapshot)` evaluated to `true` on failure (because
`-1` is non-zero), causing the code to call `Process32First` and ultimately
`CloseHandle` on an invalid handle.

Fixed both `Process::kill(bool)` and `Process::kill(id_type, bool)` to use
the correct guard:

```cpp
// Before
if(snapshot) { ... }

// After
if(snapshot != INVALID_HANDLE_VALUE) { ... }
