### PR TITLE
Add startupLoader configuration support

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -1330,6 +1330,9 @@ bool init(const json &windowOptions) {
     if(helpers::hasField(windowOptions, "skipTaskbar"))
         windowProps.skipTaskbar = windowOptions["skipTaskbar"].get<bool>();
 
+        windowProps.startupLoaderType = settings::getStartupLoaderType();
+        windowProps.startupLoaderImage = settings::getStartupLoaderImage();
+
     if(!__createWindow()) {
         return false;
     }

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -74,6 +74,8 @@ struct WindowOptions {
     string injectScript = "";
     int x = 0;
     int y = 0;
+    string startupLoaderType = "system";
+    string startupLoaderImage = "";
 };
 
 struct WindowMenuItem {

--- a/settings.cpp
+++ b/settings.cpp
@@ -377,4 +377,25 @@ json getOptionForCurrentMode(const string &key) {
     return value;
 }
 
+string getStartupLoaderType() {
+    json loader = settings::getOptionForCurrentMode("startupLoader");
+    
+    if(!loader.is_null() && loader.contains("type")) {
+        string type = loader["type"];
+        if(type == "none" || type == "system" || type == "image") {
+            return type;
+        }
+    }
+    return "system"; // default
+}
+
+string getStartupLoaderImage() {
+    json loader = settings::getOptionForCurrentMode("startupLoader");
+
+    if(!loader.is_null() && loader.contains("image")) {
+        return loader["image"];
+    }
+    return "";
+}
+
 } // namespace settings


### PR DESCRIPTION
### Summary

This PR introduces initial support for a flexible `startupLoader` configuration to improve the application startup experience.
### Changes:
* Added `startupLoaderType` and `startupLoaderImage` to `WindowOptions`
* Implemented helper functions in `settings.cpp` to read loader configuration
* Connected loader configuration to window initialization in `window.cpp`

### Example Configuration:

```json
"window": {
  "startupLoader": {
    "type": "image",
    "image": "/loader.gif"
  }
}
```
### Notes:
This PR focuses on configuration and architecture. It lays the groundwork for future platform-specific loading indicator implementations.

Related to: #814
