### PR TITLE
Fix tray menu bounds check to prevent potential overflow

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -681,11 +681,15 @@ json setTray(const json &input) {
     json output;
 
     if(helpers::hasField(input, "menuItems")) {
-        int menuCount = input["menuItems"].size();
-        menus[menuCount - 1] = { nullptr, nullptr, 0, 0, nullptr, nullptr };
+        int menuCount = static_cast<int>(input["menuItems"].size());
+        if(menuCount > NEU_MAX_TRAY_MENU_ITEMS){
+            menuCount = NEU_MAX_TRAY_MENU_ITEMS;
+        }
+        
 
         int i = 0;
         for (const auto &menuItem: input["menuItems"]) {
+            if(i >= menuCount) break;
             char *id = nullptr;
             char *text = helpers::cStrCopy(menuItem["text"].get<string>());
             int disabled = 0;
@@ -704,6 +708,9 @@ json setTray(const json &input) {
             delete[] menus[i].text;
             menus[i] = { id, text, disabled, checked, __handleTrayMenuItem, nullptr };
             i++;
+        }
+        if(menuCount < NEU_MAX_TRAY_MENU_ITEMS){
+            menus[menuCount] = { nullptr, nullptr, 0, 0, nullptr,nullptr};
         }
     }
 


### PR DESCRIPTION
## Description
This PR fixes a potential buffer overflow issue in tray menu handling.  
Previously, the number of menu items from user input was used directly without bounds checking, which could lead to out-of-bounds memory access.

## Changes proposed
- Added bounds check to limit `menuCount` using `NEU_MAX_TRAY_MENU_ITEMS`
- Prevented out-of-bounds access by limiting iteration based on `menuCount`
- Ensured proper null termination of the `menus` array

## How to test it
- Run the application and provide tray menu items via input
- Test with:
  - A normal number of items (within limit)
  - A large number of items (greater than `NEU_MAX_TRAY_MENU_ITEMS`)
- Verify:
  - No crashes or undefined behavior occur
  - Tray menu renders correctly

## Next steps
- Further input validation can be added if required.