### PR TITLE
fixed minor typos in Unreleased section of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 ## v6.7.0
 
 ### API: Input device simulation and handling
-New functions were added to the `computer` namespace to update the mouse position, confine the mouse cursor within the window, and simulate keyboard events. These functions work on Windows and macOS, but only work under the X windowing system on Linux (or FreeBSD). On Wayland, these functions will throw `NE_CO_UNLTOSC`, `NE_CO_UNLTOMG`, or `NE_CO_UNLTOSK` error messages.
+New functions were added to the `computer` namespace to update the mouse position, confine the mouse cursor within the window, and simulate keyboard events. These functions work on Windows and macOS, but only work under the X window system on Linux (or FreeBSD). On Wayland, these functions will throw `NE_CO_UNLTOSC`, `NE_CO_UNLTOMG`, or `NE_CO_UNLTOSK` error messages.
 
 - Implement `computer.setMousePosition(x, y)` to update the current mouse cursor position.
-- Implement `computer.setMouseGrabbing(grabbing; boolean)` to activate/deactivate confining the mouse cursor within the native app window. If `grabbing` is set to `true`, the mouse cursor always stays within the window boundaries, so this feature helps create interactive games and similar apps operated using the mouse.
+- Implement `computer.setMouseGrabbing(grabbing: boolean)` to activate/deactivate confining the mouse cursor within the native app window. If `grabbing` is set to `true`, the mouse cursor always stays within the window boundaries, so this feature helps create interactive games and similar apps operated using the mouse.
 - Implement `computer.sendKey(keyCode, keyState)` to simulate keyboard events. App developers can use a platform-specific key code and states (`press`, `down`, and `up`) to simulate from simple single key strokes to complex key combinations:
 ```js
 // Simulate letter 'a' press on GNU/Linux:


### PR DESCRIPTION
Changes: 
1. computer.setMouseGrabbing(grabbing; boolean) 
    changed  ;  to  :

2. the X windowing system on Linux  
    changed windowing to window

3. Suggestion for improving clarity
    to activate/deactivate confining the mouse cursor  
    to enable or disable confining the mouse cursor

