### PR TITLE
Fix race condition in spawnedProcesses map access

### DIFF
--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -216,11 +216,18 @@ pair<int, int> spawnProcess(string command, const os::ChildProcessOptions &optio
 }
 
 bool updateSpawnedProcess(const os::SpawnedProcessEvent &evt) {
-    if(spawnedProcesses.find(evt.id) == spawnedProcesses.end()) {
-        return false;
+    std::lock_guard<std::mutex> guard(spawnedProcessesLock);
+
+    auto it = spawnedProcesses.find(evt.id);
+    if(it == spawnedProcesses.end()) {
+    return false;
     }
 
-    TinyProcessLib::Process *childProcess = spawnedProcesses[evt.id];
+    TinyProcessLib::Process *childProcess = it->second;
+
+    if(childProcess == nullptr) {
+    return false;
+    }
 
     if(evt.type == "exit") {
         childProcess->kill();


### PR DESCRIPTION
## Description

This PR fixes a potential race condition in the process management logic involving the shared `spawnedProcesses` map.
Previously, `updateSpawnedProcess` accessed the map without synchronization and used direct indexing, which could lead to unsafe concurrent access and unintended insertions.

## Changes proposed

* Added mutex protection (`spawnedProcessesLock`) using `std::lock_guard` to ensure thread-safe access
* Replaced direct map access (`spawnedProcesses[evt.id]`) with iterator-based lookup (`find`)
* Accessed the process using `it->second` instead of direct indexing
* Added a null check for `childProcess` before usage

## How to test it

* Spawn multiple processes
* Trigger events like `exit` and `stdin`
* Verify:

  * No crashes or undefined behavior occur
  * Process handling works correctly

## Next steps

* Review similar shared data structures for proper synchronization
