### PR TITLE
Fix uninitialized variables in __getCenterPos

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -145,8 +145,8 @@ void windowStateChange(int state) {
 
 
 pair<int, int> __getCenterPos(bool useConfigSizes = false) {
-    int x, y = 0;
-    int width, height = 0;
+    int x = 0, y = 0;
+    int width = 0, height = 0;
     if(useConfigSizes) {
         width = windowProps.sizeOptions.width;
         height = windowProps.sizeOptions.height;


### PR DESCRIPTION
## Description
This PR fixes uninitialized variable issues in the `__getCenterPos` function.
Previously, variables were partially initialized:
This caused `x` and `width` to remain uninitialized, which could lead to undefined behavior.

## Changes proposed
- Initialized `x` and `y` explicitly
- Initialized `width` and `height` explicitly

## How to test it
- Run the application and trigger window positioning logic
- Verify:
  - No inconsistent or unexpected positioning behavior

## Next steps
- Review similar initialization patterns across the codebase