### PR TITLE
fix: guard stoi calls to prevent crashes on invalid inputs (#1583)

### DIFF
--- a/errors.cpp
+++ b/errors.cpp
@@ -75,6 +75,7 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_CF_UNBPRCF: return "NE_CF_UNBPRCF";
         case errors::NE_CF_UNSUPMD: return "NE_CF_UNSUPMD";
         case errors::NE_CF_UNBLWCF: return "NE_CF_UNBLWCF";
+        case errors::NE_CF_INVINTVAL: return "NE_CF_INVINTVAL";
     }
     return "NE_ST_NOTOK";
 }
@@ -145,6 +146,7 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_CF_UNBPRCF: return "Unable to parse the config file: %1";
         case errors::NE_CF_UNSUPMD: return "Unsupported mode: %1. The default mode (window) is selected.";
         case errors::NE_CF_UNBLWCF: return "Unable to load the window config file: %1";
+        case errors::NE_CF_INVINTVAL: return "Invalid integer value for config key '%1'. Skipping override.";
     }
     return "";
 }

--- a/errors.h
+++ b/errors.h
@@ -74,7 +74,8 @@ enum StatusCode {
     NE_CF_UNBLDCF,
     NE_CF_UNBPRCF,
     NE_CF_UNSUPMD,
-    NE_CF_UNBLWCF
+    NE_CF_UNBLWCF,
+    NE_CF_INVINTVAL
 };
 
 json makeMissingArgErrorPayload(const string& missingArg);

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -179,6 +179,18 @@ string jsonToString(const json &obj) {
     return obj.dump(-1, ' ', false, json::error_handler_t::replace);
 }
 
+bool strToInt(const string &s, int &out) {
+    if(s.empty()) return false;
+    size_t pos = 0;
+    try {
+        out = stoi(s, &pos);
+        return pos == s.size();
+    }
+    catch(...) {
+        return false;
+    }
+}
+
 #if defined(_WIN32)
 wstring str2wstr(const string &str) {
     int len = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), (int)str.size(), nullptr, 0);

--- a/helpers.h
+++ b/helpers.h
@@ -38,6 +38,7 @@ string normalizePath(string &path);
 string unNormalizePath(string &path);
 string getCurrentTimestamp();
 string jsonToString(const json &obj);
+bool strToInt(const string &s, int &out);
 
 #if defined(_WIN32)
 wstring str2wstr(const string &str);

--- a/resources.cpp
+++ b/resources.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <vector>
 #include <filesystem>
+#include <cerrno>
 
 #include "lib/postject/postject-api.h"
 #include "lib/json/json.hpp"
@@ -78,7 +79,14 @@ fs::FileReaderResult __getFileFromBundle(const string &filename, const fs::FileR
         fileReaderResult.size = p.first;
         unsigned long pos = 0;
         unsigned long size = p.first;
-        unsigned long uOffset = stoi(p.second);
+        char *endPtr = nullptr;
+        errno = 0;
+        unsigned long uOffset = strtoul(p.second.c_str(), &endPtr, 10);
+        if(endPtr == p.second.c_str() || *endPtr != '\0' || errno == ERANGE) {
+            fileReaderResult.status = errors::NE_RS_TREEGER;
+            asarArchive.close();
+            return fileReaderResult;
+        }
         __applyFileReaderOptions(fileReaderResult.size, pos, size, fileReaderOptions);
 
         vector<char>fileBuf ( size );
@@ -109,7 +117,13 @@ fs::FileReaderResult __getFileFromEmbedded(const string &filename, const fs::Fil
         fileReaderResult.size = p.first;
         unsigned long pos = 0;
         unsigned long size = p.first;
-        unsigned long uOffset = stoi(p.second);
+        char *endPtr = nullptr;
+        errno = 0;
+        unsigned long uOffset = strtoul(p.second.c_str(), &endPtr, 10);
+        if(endPtr == p.second.c_str() || *endPtr != '\0' || errno == ERANGE) {
+            fileReaderResult.status = errors::NE_RS_TREEGER;
+            return fileReaderResult;
+        }
         __applyFileReaderOptions(fileReaderResult.size, pos, size, fileReaderOptions);
 
         vector<char>fileBuf ( size );

--- a/settings.cpp
+++ b/settings.cpp
@@ -90,7 +90,13 @@ bool init() {
 
         // String to actual types
         if(cfgOverride.convertTo == "int") {
-            patch["value"] = stoi(cfgOverride.value);
+            int intVal = 0;
+            if(!helpers::strToInt(cfgOverride.value, intVal)) {
+                debug::log(debug::LogTypeError,
+                    errors::makeErrorMsg(errors::NE_CF_INVINTVAL, cfgOverride.key));
+                continue;
+            }
+            patch["value"] = intVal;
         }
         else if(cfgOverride.convertTo == "bool") {
             patch["value"] = cfgOverride.value == "true";

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -12,4 +12,45 @@ describe('config.spec: App configuration tests', () => {
         assert.ok(runner.getOutput().includes('TestUserAgentValue'));
     });
 
+    it('does not crash when a non-numeric value is passed to an integer CLI arg', async () => {
+        runner.run(`
+            await __close(NL_PORT.toString());
+        `, {args: '--port=notanumber'});
+
+        let output = runner.getOutput();
+        assert.ok(output.length > 0, 'App crashed — no output was written');
+        assert.ok(!isNaN(parseInt(output)), 'NL_PORT is not a valid number after skipped override');
+    });
+
+    it('does not crash when an out-of-range value is passed to an integer CLI arg', async () => {
+        runner.run(`
+            await __close(NL_PORT.toString());
+        `, {args: '--port=99999999999'});
+
+        let output = runner.getOutput();
+        assert.ok(output.length > 0, 'App crashed — no output was written');
+        assert.ok(!isNaN(parseInt(output)), 'NL_PORT is not a valid number after skipped override');
+    });
+
+    it('does not crash when an integer CLI arg has trailing non-numeric characters', async () => {
+        runner.run(`
+            await __close(NL_PORT.toString());
+        `, {args: '--port=42abc'});
+
+        let output = runner.getOutput();
+        assert.ok(output.length > 0, 'App crashed — no output was written');
+        assert.ok(!isNaN(parseInt(output)), 'NL_PORT is not a valid number after skipped override');
+    });
+
+    it('does not apply an invalid integer override but still applies valid overrides in the same run', async () => {
+        runner.run(`
+            await __close(navigator.userAgent);
+        `, {args: '--port=notanumber --window-extend-user-agent-with="PartialOverrideCheck"'});
+
+        let output = runner.getOutput();
+        assert.ok(output.length > 0, 'App crashed — no output was written');
+        assert.ok(output.includes('PartialOverrideCheck'),
+            'String override was not applied after skipping invalid int override');
+    });
+
 });


### PR DESCRIPTION
## Description

Unguarded `std::stoi()` calls in `settings.cpp` and `resources.cpp` caused the Neutralinojs process to terminate immediately when given non-numeric input — for example, passing `--port=notanumber` on the command line or loading a malformed resource bundle. This fix replaces those bare calls with safe, status-code-based error handling that matches the project's no-exceptions coding style.

Fixes #1583 

## Changes proposed

 - Added `helpers::strToInt()` — a reusable safe integer parse helper returning `bool` (exception never escapes to callers)
 - Added error code `NE_CF_INVINTVAL` for invalid integer config override values
 - Guarded the `stoi()` call in `settings::init()` — invalid integer CLI overrides (e.g. `--port=abc`, `--window-width=overflow`) are now logged and skipped; all other valid overrides in the same run still apply
 - Guarded both `stoi()` calls in `resources::__getFileFromBundle()` and `resources::__getFileFromEmbedded()` — malformed bundle offsets now return `NE_RS_TREEGER` instead of crashing (uses `strtoul` to also correctly handle offsets exceeding `INT_MAX`)

## How to test it

 - Run the config spec:
   ```bash
   cd spec && node index.js config
   ```
 - Manually pass an invalid integer CLI arg and confirm the app starts without crashing:
   ```bash
   ./bin/neutralino-linux_x64 --load-dir-res --port=notanumber
   ```
   Expected: app starts, `NE_CF_INVINTVAL` is logged, port falls back to the config default.

## Next steps

None.

## Deploy notes

None.

---

### Before:
<img width="1280" height="254" alt="image" src="https://github.com/user-attachments/assets/7599486d-fe0b-4452-90c2-29d5c49d17a0" />

### After:

<img width="1920" height="381" alt="image" src="https://github.com/user-attachments/assets/6d8bfdd8-3893-411b-840c-3cfdc58caaaa" />
