### PR TITLE
setskipTaskBar view

### DIFF
--- a/api/computer/computer.cpp
+++ b/api/computer/computer.cpp
@@ -519,6 +519,9 @@ json sendKey(const json &input) {
 json getNetworkInterfaces(const json &input) {
     json output;
     json interfaces = json::object();
+    bool excludeLoopback = helpers::hasField(input, "excludeLoopback") &&
+                            input["excludeLoopback"].get<bool>();
+
     #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
     struct ifaddrs *ifap, *ifa;
     if(getifaddrs(&ifap) == -1) {
@@ -529,9 +532,13 @@ json getNetworkInterfaces(const json &input) {
     for(ifa = ifap; ifa != nullptr; ifa = ifa->ifa_next) {
         if(!ifa->ifa_addr || (ifa->ifa_addr->sa_family != AF_INET && ifa->ifa_addr->sa_family != AF_INET6)) 
             continue;
+
+        bool isLoopback = (ifa->ifa_flags & IFF_LOOPBACK) != 0;
+        if(excludeLoopback && isLoopback)
+            continue;
     
         json interfaceInfo = {
-            { "isInternal", (ifa->ifa_flags & IFF_LOOPBACK) != 0 }
+            { "isInternal", isLoopback }
         };
 
         if(ifa->ifa_addr->sa_family == AF_INET) {

--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -1678,6 +1678,17 @@ json setBorderless(const json &input) {
     return output;
 }
 
+json setSkipTaskbar(const json &input) {
+    json output;
+    bool skip = true;
+    if(helpers::hasField(input, "skip")) {
+        skip = input["skip"].get<bool>();
+    }
+    window::setSkipTaskbar(skip);
+    output["success"] = true;
+    return output;
+}
+
 json getPosition(const json &input) {
     json output;
     json posRes;

--- a/api/window/window.h
+++ b/api/window/window.h
@@ -167,6 +167,7 @@ json getSize(const json &input);
 json getPosition(const json &input);
 json setAlwaysOnTop(const json &input);
 json setBorderless(const json &input);
+json setSkipTaskbar(const json &input);
 json snapshot(const json &input);
 json setMainMenu(const json &input);
 json beginDrag(const json& input);

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1116,8 +1116,8 @@ private:
                 args->get_Uri(&uri);
                 std::wstring ws(uri);
                 std::string url(ws.begin(), ws.end());
-                if(url.find("http://localhost") != 0 && url.find("http://127.0.0.1") != 0 && newWindow) {
-                    newWindow(url);
+                if(url.find("http://localhost") != 0 && url.find("http://127.0.0.1") != 0 && handleNavigation) {
+                    handleNavigation(url);
                 }
                 args->put_Handled(TRUE);
                 CoTaskMemFree(uri);

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -1192,16 +1192,6 @@ private:
       webview->add_PermissionRequested(this, &token);
       
       webview->add_NewWindowRequested(
-        Callback<ICoreWebView2NewWindowRequestedEventHandler>(
-            [](ICoreWebView2* sender,
-              ICoreWebView2NewWindowRequestedEventArgs* args) -> HRESULT {
-                LPWSTR uri;
-                args->get_Uri(&uri);
-                std::wstring ws(uri);
-                std::string url(ws.begin(), ws.end());
-                if(url.find("http://localhost") != 0 && url.find("http://127.0.0.1") != 0 && handleNavigation) {
-                    handleNavigation(url);
-                }
       Callback<ICoreWebView2NewWindowRequestedEventHandler>(
           [](ICoreWebView2* sender,
             ICoreWebView2NewWindowRequestedEventArgs* args) -> HRESULT {

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -73,6 +73,7 @@ map<string, router::NativeMethod> methodMap = {
     {"window.getPosition", window::controllers::getPosition},
     {"window.setAlwaysOnTop", window::controllers::setAlwaysOnTop},
     {"window.setBorderless", window::controllers::setBorderless},
+    {"window.setSkipTaskbar", window::controllers::setSkipTaskbar},
     {"window.snapshot", window::controllers::snapshot},
     {"window.setMainMenu", window::controllers::setMainMenu},
     {"window.print", window::controllers::print},

--- a/spec/window.spec.js
+++ b/spec/window.spec.js
@@ -339,6 +339,24 @@ describe('window.spec: window namespace tests', () => {
         });
     });
 
+    describe('window.setSkipTaskbar', () => {
+        it('exports the function to the app', async () => {
+            runner.run(`
+                await __close(typeof Neutralino.window.setSkipTaskbar);
+            `);
+            assert.equal(runner.getOutput(), 'function');
+        });
+
+        it('works without throwing errors', async () => {
+            runner.run(`
+                await Neutralino.window.setSkipTaskbar(true);
+                await Neutralino.window.setSkipTaskbar(false);
+                await __close('done');
+            `);
+            assert.equal(runner.getOutput(), 'done');
+        });
+    });
+
     describe('window.getSize', () => {
         it('returns size information', async () => {
             runner.run(`


### PR DESCRIPTION
## Description
<!--
    Give a brief explanation about the changes you are proposing.
-->
Adds runtime support for Neutralino.window.setSkipTaskbar(skip) by wiring the already existing native window::setSkipTaskbar(bool) implementation into the window API router/controller path.

This PR also fixes two Windows build blockers found while compiling the branch.

## Changes proposed
<!--
    List the changes you made, one or two bullets is ok, 3 or more is maybe
    that you are doing more than necessary.
-->
 - Add window.setSkipTaskbar native controller/router wiring and specs.
 - Fix Windows build issues in computer.getNetworkInterfaces and WebView new-window handling.

## How to test it
<!--
    Give steps to test your changes for quality assurance tests.
-->

 - Run specs/tests

## Next steps
<!--
    If your pull request is just a step in a set of steps, mention the next steps.
-->

None.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.