### PR TITLE
temp folder creation

### DIFF
--- a/api/fs/fs.cpp
+++ b/api/fs/fs.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <random>
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #include <unistd.h>
@@ -46,8 +47,37 @@ map<efsw::WatchID, pair<efsw::FileWatchListener*, string>> watchListeners;
 mutex watcherLock;
 
 #define NEU_DEFAULT_STREAM_BUF_SIZE 256
+#define NEU_TEMP_DIRECTORY_MAX_ATTEMPTS 100
 
 namespace fs {
+
+string __generateTempDirectoryName(const string &prefix) {
+    static const string characters =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+
+    random_device rd;
+    mt19937 generator(rd());
+    uniform_int_distribution<int> distribution(0, characters.size() - 1);
+
+    string name = prefix + "-";
+    for(int i = 0; i < 16; i++) {
+        name += characters[distribution(generator)];
+    }
+    return name;
+}
+
+bool __isValidTempDirectoryPrefix(const string &prefix) {
+    const string invalidCharacters = "<>:\"/\\|?*";
+
+    for(unsigned char ch: prefix) {
+        if(ch < 32 || invalidCharacters.find(ch) != string::npos) {
+            return false;
+        }
+    }
+    return true;
+}
 
 void __dispatchOpenedFileEvt(int virtualFileId, const string &action, const json &data) {
     json evt;
@@ -353,6 +383,41 @@ fs::DirReaderResult readDirectory(const string &path, bool recursive) {
     return dirResult;
 }
 
+fs::TempDirectoryResult createTempDirectory(const string &prefix) {
+    fs::TempDirectoryResult tempDirectoryResult;
+    if(!__isValidTempDirectoryPrefix(prefix)) {
+        tempDirectoryResult.status = errors::NE_FS_DIRCRER;
+        return tempDirectoryResult;
+    }
+
+    error_code ec;
+    filesystem::path tempPath = filesystem::temp_directory_path(ec);
+    if(ec) {
+        tempDirectoryResult.status = errors::NE_FS_DIRCRER;
+        return tempDirectoryResult;
+    }
+
+    for(int i = 0; i < NEU_TEMP_DIRECTORY_MAX_ATTEMPTS; i++) {
+        string tempDirectoryName = __generateTempDirectoryName(prefix);
+        filesystem::path tempDirectoryPath = tempPath / filesystem::path(CONVSTR(tempDirectoryName));
+
+        ec.clear();
+        if(filesystem::create_directory(tempDirectoryPath, ec)) {
+            string path = FS_CONVWSTR(tempDirectoryPath);
+            tempDirectoryResult.path = helpers::normalizePath(path);
+            return tempDirectoryResult;
+        }
+
+        if(ec) {
+            tempDirectoryResult.status = errors::NE_FS_DIRCRER;
+            return tempDirectoryResult;
+        }
+    }
+
+    tempDirectoryResult.status = errors::NE_FS_DIRCRER;
+    return tempDirectoryResult;
+}
+
 string applyPathConstants(const string &path) {
     string newPath = regex_replace(path, regex("\\$\\{NL_PATH\\}"), settings::getAppPath());
 
@@ -420,6 +485,28 @@ json createDirectory(const json &input) {
     }
     else {
         output["error"] = errors::makeErrorPayload(errors::NE_FS_DIRCRER, path);
+    }
+    return output;
+}
+
+json createTempDirectory(const json &input) {
+    json output;
+    string prefix = "neutralino";
+
+    if(helpers::hasField(input, "prefix")) {
+        prefix = input["prefix"].get<string>();
+        if(prefix.empty()) {
+            prefix = "neutralino";
+        }
+    }
+
+    fs::TempDirectoryResult tempDirectoryResult = fs::createTempDirectory(prefix);
+    if(tempDirectoryResult.status == errors::NE_ST_OK) {
+        output["returnValue"] = tempDirectoryResult.path;
+        output["success"] = true;
+    }
+    else {
+        output["error"] = errors::makeErrorPayload(tempDirectoryResult.status, prefix);
     }
     return output;
 }

--- a/api/fs/fs.h
+++ b/api/fs/fs.h
@@ -57,6 +57,11 @@ struct DirReaderResult {
     vector<DirReaderEntry> entries;
 };
 
+struct TempDirectoryResult {
+    errors::StatusCode status = errors::NE_ST_OK;
+    string path;
+};
+
 fs::FileReaderResult readFile(const string &filename, const fs::FileReaderOptions &fileReaderOptions = {});
 bool writeFile(const fs::FileWriterOptions &fileWriterOptions);
 string getDirectoryName(const string &filename);
@@ -67,11 +72,13 @@ long createWatcher(const string &path);
 bool removeWatcher(long watcherId);
 fs::FileStats getStats(const string &path);
 fs::DirReaderResult readDirectory(const string &path, bool recursive = false);
+fs::TempDirectoryResult createTempDirectory(const string &prefix);
 string applyPathConstants(const string &path);
 
 namespace controllers {
 
 json createDirectory(const json &input);
+json createTempDirectory(const json &input);
 json remove(const json &input);
 json writeFile(const json &input);
 json writeBinaryFile(const json &input);

--- a/server/router.cpp
+++ b/server/router.cpp
@@ -98,6 +98,7 @@ map<string, router::NativeMethod> methodMap = {
     {"debug.log", debug::controllers::log},
     // Neutralino.filesystem
     {"filesystem.createDirectory", fs::controllers::createDirectory},
+    {"filesystem.createTempDirectory", fs::controllers::createTempDirectory},
     {"filesystem.remove", fs::controllers::remove},
     {"filesystem.readFile", fs::controllers::readFile},
     {"filesystem.readBinaryFile", fs::controllers::readBinaryFile},

--- a/spec/filesystem.spec.js
+++ b/spec/filesystem.spec.js
@@ -50,6 +50,57 @@ describe('filesystem.spec: filesystem namespace tests', () => {
         });
     });
 
+    describe('filesystem.createTempDirectory', () => {
+        it('works without options', async () => {
+            runner.run(`
+                let tempPath = await Neutralino.filesystem.createTempDirectory();
+                let tempRoot = await Neutralino.os.getPath('temp');
+                let stats = await Neutralino.filesystem.getStats(tempPath);
+                await Neutralino.filesystem.remove(tempPath);
+                await __close(JSON.stringify({
+                    inTemp: tempPath.startsWith(tempRoot + '/'),
+                    isDirectory: stats.isDirectory
+                }));
+            `);
+            const result = JSON.parse(runner.getOutput());
+            assert.equal(result.inTemp, true);
+            assert.equal(result.isDirectory, true);
+        });
+
+        it('uses a custom prefix', async () => {
+            runner.run(`
+                let tempPath = await Neutralino.filesystem.createTempDirectory({ prefix: 'neu_folder' });
+                let directoryName = tempPath.split('/').pop();
+                await Neutralino.filesystem.remove(tempPath);
+                await __close(directoryName);
+            `);
+            assert.equal(runner.getOutput().startsWith('neu_folder-'), true);
+        });
+
+        it('creates unique directories', async () => {
+            runner.run(`
+                let tempPath1 = await Neutralino.filesystem.createTempDirectory({ prefix: 'neu_folder' });
+                let tempPath2 = await Neutralino.filesystem.createTempDirectory({ prefix: 'neu_folder' });
+                let result = tempPath1 != tempPath2;
+                await Neutralino.filesystem.remove(tempPath1);
+                await Neutralino.filesystem.remove(tempPath2);
+                await __close(result.toString());
+            `);
+            assert.equal(runner.getOutput(), 'true');
+        });
+
+        it('throws an error for invalid prefixes', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.filesystem.createTempDirectory({ prefix: '../neu_folder' });
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `);
+            assert.equal(runner.getOutput(), 'NE_FS_DIRCRER');
+        });
+    });
+
     describe('filesystem.remove', () => {
         it('works without throwing errors', async () => {
             runner.run(`


### PR DESCRIPTION
## Description
Adds `filesystem.createTempDirectory()` to create unique OS temp directories with an optional prefix.

## Changes proposed
- Implemented native `filesystem.createTempDirectory(options)` and routed it through the filesystem API.

## How to test it
- Build NeutralinoJS.
- Run filesystem specs.

## Next steps
None.

## Deploy notes
None.