### PR TITLE
fix(computer): correct sendKey declaration

### DIFF
--- a/api/computer/computer.cpp
+++ b/api/computer/computer.cpp
@@ -337,7 +337,7 @@ bool setMouseGrabbing(bool grabbing = true) {
     #endif
 }
 
-bool sendKey(unsigned int keyCode, computer::SendKeyState keyState = computer::SendKeyStatePress) {
+bool sendKey(unsigned int keyCode, computer::SendKeyState keyState) {
     #if defined(_WIN32)
     INPUT in {};
     in.type = INPUT_KEYBOARD;

--- a/api/computer/computer.h
+++ b/api/computer/computer.h
@@ -15,7 +15,7 @@ enum SendKeyState { SendKeyStatePress, SendKeyStateDown, SendKeyStateUp };
 
 bool setMousePosition(int x, int y);
 bool setMouseGrabbing(bool grabbing);
-bool sendKey(const string &key, computer::SendKeyState keyState);
+bool sendKey(unsigned int keyCode, computer::SendKeyState keyState = computer::SendKeyStatePress);
 
 string getArch();
 pair<int, int> getMousePosition();


### PR DESCRIPTION
## Description

Fixes the `computer::sendKey` declaration in `api/computer/computer.h` so that it matches the implementation.

### Changes
- Changed `sendKey` parameter from `const string &key` to `unsigned int keyCode`.
- Added the default value `SendKeyStatePress` to the declaration.
- Kept the implementation signature consistent by removing the default argument from the `.cpp` definition.

### Why

The declaration in `computer.h` did not match the actual implementation in `computer.cpp`. This could cause an inconsistent function declaration and compilation issues when using the native `computer::sendKey` API.

### Validation
- `git diff --check` passes.
- Working tree is clean.
- Branch successfully pushed to the fork.