### PR TITLE
fix config file loading

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -62,7 +62,7 @@ bool init() {
     localeName = localeInfo.locale;
     options = json::object();
     json config;
-    fs::FileReaderResult fileReaderResult = resources::getFile(configFile);
+    fs::FileReaderResult fileReaderResult = fs::readFile(configFile);
     if(fileReaderResult.status == errors::NE_ST_OK) {
         try {
             config = json::parse(fileReaderResult.data);

--- a/settings.h
+++ b/settings.h
@@ -18,7 +18,7 @@
 
 #endif
 
-#define NEU_APP_CONFIG_FILE "/neutralino.config.json"
+#define NEU_APP_CONFIG_FILE "neutralino.config.json"
 
 #if !defined(NEU_COMPILATION_DATA)
 #define NEU_COMPILATION_DATA ""


### PR DESCRIPTION
## Description
Resolves #1814.

## Changes proposed
This change makes it so the path provided to the `--config-file` parameter is not treated as a resource path.  The file gets resolved from the file system following standard CLI path semantics.  This means both absolute paths and relative paths work.

## How to test it
Run `neu run -- --config-file=test.json` with a `test.json` config in the local directory.  

## Next steps
None.

## Deploy notes
None.