### PR TITLE
Add ability to set a whitelist of allowed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### API: os
+- Add command allow-listing: Restrict `os.execCommand` and `os.spawnProcess` to a configurable set of allowed programs via the new `os.allowCommands` configuration option. When this option is set with one or more entries, the framework rejects any command whose program name (argv[0]) does not match an entry with the new `NE_OS_CMDNALLW` error. Patterns support `*` and `?` wildcards. The command is parsed with simple shell-quote rules; unquoted shell metacharacters (`;|&><$`(){}` and newline) reject the command outright so `os.allowCommands` cannot be used to run piped or redirected commands.
+
+  Example configuration:
+
+  ```json
+  {
+    "os": {
+      "allowCommands": [
+        "git",
+        "node",
+        "python3 *"
+      ]
+    }
+  }
+  ```
+
+  If the list is empty or omitted, no restriction is applied. A list containing only `*` (or any other pattern that matches every program) is equivalent to omitting the option.
+
 ## v6.9.0
 
 ### API: net

--- a/api/os/os.cpp
+++ b/api/os/os.cpp
@@ -390,6 +390,133 @@ bool setEnv(const string &key, const string &value) {
     #endif
 }
 
+bool __globMatch(const string &value, const string &pattern) {
+    string regexStr = "^";
+    for(const char c: pattern) {
+        switch(c) {
+            case '*': regexStr += ".*"; break;
+            case '?': regexStr += "."; break;
+            case '.': case '\\': case '+': case '(': case ')':
+            case '[': case ']': case '{': case '}': case '|':
+            case '^': case '$': case '#': regexStr += "\\"; [[fallthrough]];
+            default: regexStr += c; break;
+        }
+    }
+    regexStr += "$";
+    try {
+        return regex_match(value, regex(regexStr));
+    }
+    catch(const regex_error &) {
+        return false;
+    }
+}
+
+vector<string> __tokenizeCommand(const string &command) {
+    vector<string> tokens;
+    string current;
+    bool inSingle = false;
+    bool inDouble = false;
+
+    auto flushToken = [&](void) {
+        if(!current.empty()) {
+            tokens.push_back(current);
+            current.clear();
+        }
+    };
+
+    for(size_t i = 0; i < command.size(); i++) {
+        unsigned char c = static_cast<unsigned char>(command[i]);
+        if(!inSingle && !inDouble) {
+            if(isspace(c)) {
+                flushToken();
+            }
+            else if(c == '\'') {
+                inSingle = true;
+            }
+            else if(c == '"') {
+                inDouble = true;
+            }
+            else if(strchr(";|&><$`(){}\\\n\r", c) != nullptr) {
+                tokens.clear();
+                return tokens;
+            }
+            else {
+                current += static_cast<char>(c);
+            }
+        }
+        else if(inSingle) {
+            if(c == '\'') {
+                inSingle = false;
+            }
+            else if(c == '\\' && i + 1 < command.size()) {
+                current += command[++i];
+            }
+            else {
+                current += static_cast<char>(c);
+            }
+        }
+        else {
+            if(c == '"') {
+                inDouble = false;
+            }
+            else if(c == '\\' && i + 1 < command.size()) {
+                current += command[++i];
+            }
+            else {
+                current += static_cast<char>(c);
+            }
+        }
+    }
+    if(inSingle || inDouble) {
+        tokens.clear();
+        return tokens;
+    }
+    flushToken();
+    return tokens;
+}
+
+bool __isCommandAllowed(const string &command) {
+    static vector<string> allowedPatterns;
+    static bool patternsInitialized = false;
+
+    if(!patternsInitialized) {
+        patternsInitialized = true;
+        json jOs = settings::getOptionForCurrentMode("os");
+        if(jOs.is_object()) {
+            json jAllow = jOs["allowCommands"];
+            if(jAllow.is_array()) {
+                for(const auto &entry: jAllow) {
+                    if(entry.is_string()) {
+                        allowedPatterns.push_back(entry.get<string>());
+                    }
+                }
+            }
+        }
+    }
+
+    if(allowedPatterns.empty()) {
+        return true;
+    }
+
+    vector<string> tokens = __tokenizeCommand(command);
+    if(tokens.empty()) {
+        return false;
+    }
+
+    string program = tokens[0];
+    size_t slash = program.find_last_of("/\\");
+    if(slash != string::npos) {
+        program = program.substr(slash + 1);
+    }
+
+    for(const string &pattern: allowedPatterns) {
+        if(__globMatch(program, pattern)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 namespace controllers {
 
 vector<string> __extensionsToVector(const json &filters) {
@@ -416,6 +543,12 @@ json execCommand(const json &input) {
         return output;
     }
     string command = input["command"].get<string>();
+
+    if(!__isCommandAllowed(command)) {
+        output["error"] = errors::makeErrorPayload(errors::NE_OS_CMDNALLW, command);
+        return output;
+    }
+
     os::ChildProcessOptions processOptions;
 
     if(helpers::hasField(input, "stdIn")) {
@@ -456,6 +589,12 @@ json spawnProcess(const json &input) {
     }
     
     string command = input["command"].get<string>();
+
+    if(!__isCommandAllowed(command)) {
+        output["error"] = errors::makeErrorPayload(errors::NE_OS_CMDNALLW, command);
+        return output;
+    }
+
     os::ChildProcessOptions processOptions;
     
     if(helpers::hasField(input, "cwd")) {

--- a/bin/neutralino.config.json
+++ b/bin/neutralino.config.json
@@ -21,6 +21,9 @@
         "writeToLogFile": true
     },
     "nativeBlockList": [],
+    "os": {
+        "allowCommands": []
+    },
     "globalVariables": {
         "TEST1": "Hello",
         "TEST2": [2, 4, 5],

--- a/errors.cpp
+++ b/errors.cpp
@@ -27,6 +27,7 @@ string __getStatusCodeString(const errors::StatusCode code) {
         case errors::NE_OS_INVKNPT: return "NE_OS_INVKNPT";
         case errors::NE_OS_UNLTRAS: return "NE_OS_UNLTRAS";
         case errors::NE_OS_UNLTOUV: return "NE_OS_UNLTOUV";
+        case errors::NE_OS_CMDNALLW: return "NE_OS_CMDNALLW";
         // computer
         case errors::NE_CO_UNLTOSC: return "NE_CO_UNLTOSC";
         case errors::NE_CO_UNLTOMG: return "NE_CO_UNLTOMG";
@@ -105,6 +106,7 @@ string __findStatusCodeDesc(errors::StatusCode code) {
         case errors::NE_OS_INVKNPT: return "Invalid platform path name: %1";
         case errors::NE_OS_UNLTRAS: return "Unable to move %1 item to trash";
         case errors::NE_OS_UNLTOUV: return "Unable to set environment variable";
+        case errors::NE_OS_CMDNALLW: return "Command %1 is not allowed by the os.allowCommands policy";
         // computer
         case errors::NE_CO_UNLTOSC: return "Unable to set mouse cursor";
         case errors::NE_CO_UNLTONI: return "Unable to retrieve network interfaces";

--- a/errors.h
+++ b/errors.h
@@ -27,6 +27,7 @@ enum StatusCode {
     NE_OS_INVKNPT,
     NE_OS_UNLTRAS,
     NE_OS_UNLTOUV,
+    NE_OS_CMDNALLW,
     // computer
     NE_CO_UNLTOSC,
     NE_CO_UNLTOMG,

--- a/schemas/neutralino.config.schema.json
+++ b/schemas/neutralino.config.schema.json
@@ -112,6 +112,19 @@
         }
       }
     },
+    "os": {
+      "type": "object",
+      "description": "OS-related configuration options.",
+      "properties": {
+        "allowCommands": {
+          "type": "array",
+          "description": "An array of shell-command programs that can be executed through 'os.execCommand' and 'os.spawnProcess'. When this option is set with one or more entries, the framework rejects any command whose program name doesn't match an entry with the 'NE_OS_CMDNALLW' error. If the list is empty or omitted, no restriction is applied. Patterns support the '*' and '?' wildcards (applied only to the program's executable name — argv[0] — not the full command line). The command is parsed with simple shell-quote rules; unquoted shell metacharacters (';|&><$`(){}' and newline) reject the command outright so 'os.allowCommands' cannot be used to run piped/redirected commands. \n\n { \n   \"os\": { \n     \"allowCommands\": [ \n       \"git\", \n       \"node\", \n       \"python3 *\" \n     ] \n   } \n } \n\n A list containing only '*' (or any pattern that matches everything) behaves like 'no restriction' — equivalent to omitting the option.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "applicationId": {
       "type": "string",
       "description": "Unique string to identify your application. \n Eg: js.neutralino.sample",

--- a/spec/os.spec.js
+++ b/spec/os.spec.js
@@ -642,4 +642,128 @@ describe('os.spec: os namespace tests', () => {
             assert.equal(runner.getOutput(), 'NE_OS_INVKNPT');
         });
     });
+
+    describe('os.allowCommands', () => {
+        const nodePath = require('path');
+        const fsSpec = require('fs');
+        const baseConfig = require('../bin/neutralino.config.json');
+        const SCOPED_CONFIG_PATH = nodePath.join(__dirname, '..', 'bin', '_os_allow_test.config.json');
+        const SCOPED_CONFIG_FILE = '/_os_allow_test.config.json';
+
+        before(() => {
+            const configCopy = JSON.parse(JSON.stringify(baseConfig));
+            configCopy.os = { allowCommands: ['node'] };
+            configCopy.applicationId = 'js.neutralino.allowcommands';
+            configCopy.enableNativeAPI = true;
+            fsSpec.writeFileSync(SCOPED_CONFIG_PATH, JSON.stringify(configCopy, null, 4));
+        });
+
+        after(() => {
+            try {
+                fsSpec.unlinkSync(SCOPED_CONFIG_PATH);
+            }
+            catch (err) {
+                // ignore
+            }
+        });
+
+        const scopedArgs = '--config-file=' + SCOPED_CONFIG_FILE;
+
+        it('allows execCommand for an allowed program', async () => {
+            runner.run(`
+                try {
+                    const r = await Neutralino.os.execCommand('node --version');
+                    await __close('OK:' + r.exitCode);
+                } catch (error) {
+                    await __close('ERR:' + error.code);
+                }
+            `, { args: scopedArgs });
+            assert.match(runner.getOutput(), /^OK:\d+$/);
+        });
+
+        it('rejects execCommand for a non-allowed program', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.os.execCommand('cmd /c exit 0');
+                    await __close('no-error');
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `, { args: scopedArgs });
+            assert.equal(runner.getOutput(), 'NE_OS_CMDNALLW');
+        });
+
+        it('rejects execCommand when the program does not match the allow-list', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.os.execCommand('python3 --version');
+                    await __close('no-error');
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `, { args: scopedArgs });
+            assert.equal(runner.getOutput(), 'NE_OS_CMDNALLW');
+        });
+
+        it('rejects execCommand that contains a shell pipe outside quotes', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.os.execCommand('node --version | echo hi');
+                    await __close('no-error');
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `, { args: scopedArgs });
+            assert.equal(runner.getOutput(), 'NE_OS_CMDNALLW');
+        });
+
+        it('rejects execCommand that contains a shell semicolon outside quotes', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.os.execCommand('node --version; echo hi');
+                    await __close('no-error');
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `, { args: scopedArgs });
+            assert.equal(runner.getOutput(), 'NE_OS_CMDNALLW');
+        });
+
+        it('allows execCommand with quoted arguments containing spaces', async () => {
+            runner.run(`
+                try {
+                    const r = await Neutralino.os.execCommand('node -e "console.log(42)"');
+                    await __close('OK:' + r.exitCode);
+                } catch (error) {
+                    await __close('ERR:' + error.code);
+                }
+            `, { args: scopedArgs });
+            assert.match(runner.getOutput(), /^OK:\d+$/);
+        });
+
+        it('rejects spawnProcess for a non-allowed program', async () => {
+            runner.run(`
+                try {
+                    await Neutralino.os.spawnProcess('cmd /c exit 0');
+                    await __close('no-error');
+                } catch (error) {
+                    await __close(error.code);
+                }
+            `, { args: scopedArgs });
+            assert.equal(runner.getOutput(), 'NE_OS_CMDNALLW');
+        });
+
+        it('allows spawnProcess for an allowed program', async () => {
+            runner.run(`
+                try {
+                    const r = await Neutralino.os.spawnProcess('node');
+                    await Neutralino.os.updateSpawnedProcess(r.id, 'exit');
+                    await __close('OK:' + r.id);
+                } catch (error) {
+                    await __close('ERR:' + error.code);
+                }
+            `, { args: scopedArgs });
+            assert.match(runner.getOutput(), /^OK:-?\d+$/);
+        });
+    });
 });


### PR DESCRIPTION
This pull request adds a new configuration directive `os.allowCommands` for limiting the use of commands to a given list of commands.

Example of use:

  ```json
  {
    ...
    "os": {
      "allowCommands": [
        "git",
        "node",
        "python3 *"
      ]
    },
    ...
  }
  ```