### PR TITLE
Remove unnecessary windowHandle extern declaration

### DIFF
--- a/api/window/window.h
+++ b/api/window/window.h
@@ -35,9 +35,6 @@ using namespace std;
 
 namespace window {
 
-// TODO: remove extern and fix multiple include errors
-extern NEU_W_HANDLE windowHandle;
-
 enum NewWindowPolicy { NewWindowPolicySystem, NewWindowPolicyBrowser, NewWindowPolicyCustom };
 
 struct SizeOptions {


### PR DESCRIPTION
Removed the unnecessary `extern` declaration of `windowHandle` from `window.h`.

`windowHandle` is already defined and used only in `window.cpp`, so the header declaration was not needed.

I also built the project using CMake and Ninja after the change, and the build completed successfully on Linux.
